### PR TITLE
SaveStateLoad callback/event

### DIFF
--- a/Source/Core/Core/API/Events.h
+++ b/Source/Core/Core/API/Events.h
@@ -30,6 +30,11 @@ struct MemoryBreakpoint
   u32 addr;
   u64 value;
 };
+struct SaveStateLoad
+{
+  bool bFromSlot;
+  int slot;
+};
 struct CodeBreakpoint
 {
   u32 addr;
@@ -180,7 +185,7 @@ private:
 
 // all existing events need to be listed here, otherwise there will be spooky templating errors
 using EventHub = GenericEventHub<Events::FrameAdvance, Events::FrameDrawn, Events::SetInterrupt, Events::ClearInterrupt,
-                                 Events::MemoryBreakpoint, Events::CodeBreakpoint>;
+                                 Events::MemoryBreakpoint, Events::SaveStateLoad, Events::CodeBreakpoint>;
 
 // global event hub
 EventHub& GetEventHub();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -366,7 +366,7 @@ static void CpuThread(const std::optional<std::string>& savestate_path, bool del
 
   if (savestate_path)
   {
-    ::State::LoadAs(*savestate_path);
+    ::State::LoadFile(*savestate_path);
     if (delete_savestate)
       File::Delete(*savestate_path);
   }

--- a/Source/Core/Core/State.h
+++ b/Source/Core/Core/State.h
@@ -54,6 +54,7 @@ void Save(int slot, bool wait = false);
 void Load(int slot);
 
 void SaveAs(const std::string& filename, bool wait = false);
+void LoadFile(const std::string& filename);
 void LoadAs(const std::string& filename);
 
 void SaveToBuffer(std::vector<u8>& buffer);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1324,7 +1324,7 @@ void MainWindow::StateLoad()
   QString path =
       DolphinFileDialog::getOpenFileName(this, tr("Select a File"), QDir::currentPath(),
                                          tr("All Save States (*.sav *.s##);; All Files (*)"));
-  State::LoadAs(path.toStdString());
+  State::LoadFile(path.toStdString());
 }
 
 void MainWindow::StateSave()

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -130,7 +130,7 @@ void RenderWidget::dropEvent(QDropEvent* event)
     return;
   }
 
-  State::LoadAs(path.toStdString());
+  State::LoadFile(path.toStdString());
 }
 
 void RenderWidget::OnHideCursorChanged()

--- a/Source/Core/Scripting/Python/Modules/savestatemodule.cpp
+++ b/Source/Core/Scripting/Python/Modules/savestatemodule.cpp
@@ -71,7 +71,7 @@ static PyObject* LoadFromFile(PyObject* self, PyObject* args)
   if (!filename_opt.has_value())
     return nullptr;
   const char* filename = std::get<0>(filename_opt.value());
-  State::LoadAs(std::string(filename));
+  State::LoadFile(std::string(filename));
   Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Fires a new SaveStateLoad event on savestate slot/file load. Had to add an intermediary function to differentiate between the slot and file case, so that we assure one event firing per load scenario.