### PR TITLE
SaveStateSave callback/event

### DIFF
--- a/Source/Core/Core/API/Events.h
+++ b/Source/Core/Core/API/Events.h
@@ -30,11 +30,6 @@ struct MemoryBreakpoint
   u32 addr;
   u64 value;
 };
-struct SaveStateLoad
-{
-  bool bFromSlot;
-  int slot;
-};
 struct CodeBreakpoint
 {
   u32 addr;
@@ -46,6 +41,16 @@ struct SetInterrupt
 struct ClearInterrupt
 {
   u32 cause_mask;
+};
+struct SaveStateSave
+{
+  bool toSlot;
+  int slot;
+};
+struct SaveStateLoad
+{
+  bool fromSlot;
+  int slot;
 };
 
 }  // namespace API::Events
@@ -184,8 +189,16 @@ private:
 };
 
 // all existing events need to be listed here, otherwise there will be spooky templating errors
-using EventHub = GenericEventHub<Events::FrameAdvance, Events::FrameDrawn, Events::SetInterrupt, Events::ClearInterrupt,
-                                 Events::MemoryBreakpoint, Events::SaveStateLoad, Events::CodeBreakpoint>;
+using EventHub = GenericEventHub<
+  Events::FrameAdvance,
+  Events::FrameDrawn,
+  Events::MemoryBreakpoint,
+  Events::CodeBreakpoint,
+  Events::SetInterrupt,
+  Events::ClearInterrupt,
+  Events::SaveStateSave,
+  Events::SaveStateLoad
+>;
 
 // global event hub
 EventHub& GetEventHub();

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -579,7 +579,7 @@ bool BeginRecordingInput(const ControllerTypeArray& controllers,
       if (File::Exists(save_path))
         File::Delete(save_path);
 
-      State::SaveAs(save_path);
+      State::SaveFile(save_path);
       s_bRecordingFromSaveState = true;
 
       std::thread md5thread(GetMD5);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -553,14 +553,20 @@ static void LoadFileStateData(const std::string& filename, std::vector<u8>& ret_
   ret_data.swap(buffer);
 }
 
-// Malleo - We want to emit an API event on savestate load.
-// Slot loads first pass through Load() and then LoadAs(),
-// whereas file loads ONLY pass through LoadAs().
-// To catch both scenarios, we want to first pass file loads through a separate function.
+// Malleo - We want to emit an API event on savestate load/save.
+// Slot loads/saves first pass through Load()/Save() and then LoadAs()/SaveAs(),
+// whereas file loads/saves ONLY pass through LoadAs()/SaveAs().
+// To catch both scenarios, we want to first pass file loads/saves through a separate function.
 void LoadFile(const std::string& filename)
 {
-  API::GetEventHub().EmitEvent(API::Events::SaveStateLoad(false, -1));
   LoadAs(filename);
+  API::GetEventHub().EmitEvent(API::Events::SaveStateLoad(false, -1));
+}
+
+void SaveFile(const std::string& filename, bool wait)
+{
+  SaveAs(filename, wait);
+  API::GetEventHub().EmitEvent(API::Events::SaveStateSave(false, -1));
 }
 
 void LoadAs(const std::string& filename)
@@ -673,12 +679,13 @@ static std::string MakeStateFilename(int number)
 void Save(int slot, bool wait)
 {
   SaveAs(MakeStateFilename(slot), wait);
+  API::GetEventHub().EmitEvent(API::Events::SaveStateSave(true, slot));
 }
 
 void Load(int slot)
 {
-  API::GetEventHub().EmitEvent(API::Events::SaveStateLoad(true, slot));
   LoadAs(MakeStateFilename(slot));
+  API::GetEventHub().EmitEvent(API::Events::SaveStateLoad(true, slot));
 }
 
 void LoadLastSaved(int i)

--- a/Source/Core/Core/State.h
+++ b/Source/Core/Core/State.h
@@ -53,6 +53,7 @@ u64 GetUnixTimeOfSlot(int slot);
 void Save(int slot, bool wait = false);
 void Load(int slot);
 
+void SaveFile(const std::string& filename, bool wait = false);
 void SaveAs(const std::string& filename, bool wait = false);
 void LoadFile(const std::string& filename);
 void LoadAs(const std::string& filename);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1332,7 +1332,7 @@ void MainWindow::StateSave()
   QString path =
       DolphinFileDialog::getSaveFileName(this, tr("Select a File"), QDir::currentPath(),
                                          tr("All Save States (*.sav *.s##);; All Files (*)"));
-  State::SaveAs(path.toStdString());
+  State::SaveFile(path.toStdString());
 }
 
 void MainWindow::StateLoadSlot()

--- a/Source/Core/Scripting/Python/Modules/savestatemodule.cpp
+++ b/Source/Core/Scripting/Python/Modules/savestatemodule.cpp
@@ -59,7 +59,7 @@ static PyObject* SaveToFile(PyObject* self, PyObject* args)
   if (!filename_opt.has_value())
     return nullptr;
   const char* filename = std::get<0>(filename_opt.value());
-  State::SaveAs(std::string(filename));
+  State::SaveFile(std::string(filename));
   Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
- Fires a new SaveStateSave event on savestate slot/file save. Had to add an intermediary function to differentiate between the slot and file case, so that we assure one event firing per save scenario.
- Also moves event fire to occur AFTER state is saved/loaded. Due to timings, it would have been possible for the script to recognize a state load BEFORE it actually occurred. This could result in memory reads reflecting a point before the state load.
- Reorganize events to maintain constant order
- Keep consistent boolean naming convention