### PR TITLE
Add support to set/get Nunchuck buttons/stick

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include "Core/HW/WiimoteEmu/Extension/Extension.h"
-
 #include <array>
 #include <string>
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
@@ -111,7 +111,7 @@ public:
 
     // buttons + accelerometer LSBs
     ButtonFormat bt;
-  };
+  } data_format;
   static_assert(sizeof(DataFormat) == 6, "Wrong size");
 
   struct CalibrationData

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -506,7 +506,7 @@ void Wiimote::SendDataReport()
   DataReportBuilder rpt_builder(m_reporting_mode);
 
   if (Movie::IsPlayingInput() &&
-      Movie::PlayWiimote(m_index, rpt_builder, m_active_extension, GetExtensionEncryptionKey()))
+      Movie::PlayWiimote(m_index, rpt_builder))
   {
     // Update buttons in status struct from movie:
     rpt_builder.GetCoreData(&m_status.buttons);
@@ -586,6 +586,12 @@ void Wiimote::SendDataReport()
     Movie::CallWiiInputManip(rpt_builder, m_index, m_active_extension, GetExtensionEncryptionKey());
     API::GetWiiButtonsManip().PerformInputManip(rpt_builder, m_index);
     API::GetWiiIRManip().PerformInputManip(rpt_builder, m_index);
+
+    if (rpt_builder.HasExt() && GetActiveExtensionNumber() == NUNCHUK)
+    {
+      API::GetNunchuckButtonsManip().PerformInputManip(rpt_builder, m_index,
+                                                       GetExtensionEncryptionKey());
+    }
   }
 
   if (NetPlay::IsNetPlayRunning())
@@ -598,6 +604,12 @@ void Wiimote::SendDataReport()
   }
 
   Movie::CheckWiimoteStatus(m_index, rpt_builder, m_active_extension, GetExtensionEncryptionKey());
+
+  if (rpt_builder.HasExt() && GetActiveExtensionNumber() == NUNCHUK)
+  {
+    API::GetNunchuckButtonsManip().SaveNunchuckState(rpt_builder, m_index,
+                                                     GetExtensionEncryptionKey());
+  }
 
   // Send the report:
   InterruptDataInputCallback(rpt_builder.GetDataPtr(), rpt_builder.GetDataSize());

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1278,8 +1278,7 @@ void PlayController(GCPadStatus* PadStatus, int controllerID)
 }
 
 // NOTE: CPU Thread
-bool PlayWiimote(int wiimote, WiimoteCommon::DataReportBuilder& rpt, int ext,
-                 const EncryptionKey& key)
+bool PlayWiimote(int wiimote, WiimoteCommon::DataReportBuilder& rpt)
 {
   if (!IsPlayingInput() || !IsUsingWiimote(wiimote) || s_temp_input.empty())
     return false;

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -186,8 +186,7 @@ bool PlayInput(const std::string& movie_path, std::optional<std::string>* savest
 void LoadInput(const std::string& movie_path);
 void ReadHeader();
 void PlayController(GCPadStatus* PadStatus, int controllerID);
-bool PlayWiimote(int wiimote, WiimoteCommon::DataReportBuilder& rpt, int ext,
-                 const WiimoteEmu::EncryptionKey& key);
+bool PlayWiimote(int wiimote, WiimoteCommon::DataReportBuilder& rpt);
 void EndPlayInput(bool cont);
 void SaveRecording(const std::string& filename);
 void DoState(PointerWrap& p);

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -88,7 +88,7 @@ public:
   template <typename T>
   static T ApplyDeadzone(T input, std::common_type_t<T> deadzone)
   {
-    return std::copysign(std::max(T{0}, std::abs(input) - deadzone) / (T{1} - deadzone), input);
+    return ::copysign(std::max(T{0}, std::abs(input) - deadzone) / (T{1} - deadzone), input);
   }
 
   const std::string name;

--- a/Source/Core/Scripting/Python/PyScriptingBackend.cpp
+++ b/Source/Core/Scripting/Python/PyScriptingBackend.cpp
@@ -112,9 +112,9 @@ static void ShutdownMainPythonInterpreter()
 PyScriptingBackend::PyScriptingBackend(std::filesystem::path script_filepath,
                                        API::EventHub& event_hub, API::Gui& gui,
                                        API::GCManip& gc_manip, API::WiiButtonsManip& wii_buttons_manip,
-                                       API::WiiIRManip& wii_ir_manip)
-    : m_event_hub(event_hub), m_gui(gui), m_gc_manip(gc_manip), m_wii_buttons_manip(wii_buttons_manip),
-      m_wii_ir_manip(wii_ir_manip)
+                                       API::WiiIRManip& wii_ir_manip, API::NunchuckButtonsManip& nunchuck_buttons_manip)
+    : m_event_hub(event_hub), m_gui(gui), m_gc_manip(gc_manip), m_wii_buttons_manip(wii_buttons_manip), m_wii_ir_manip(wii_ir_manip),
+      m_nunchuck_buttons_manip(nunchuck_buttons_manip)
 {
   std::lock_guard lock{s_bookkeeping_lock};
   if (s_instances.empty())
@@ -263,6 +263,11 @@ API::WiiButtonsManip* PyScriptingBackend::GetWiiButtonsManip()
 API::WiiIRManip* PyScriptingBackend::GetWiiIRManip()
 {
   return &m_wii_ir_manip;
+}
+
+API::NunchuckButtonsManip* PyScriptingBackend::GetNunchuckButtonsManip()
+{
+  return &m_nunchuck_buttons_manip;
 }
 
 void PyScriptingBackend::AddCleanupFunc(std::function<void()> cleanup_func)

--- a/Source/Core/Scripting/Python/PyScriptingBackend.h
+++ b/Source/Core/Scripting/Python/PyScriptingBackend.h
@@ -20,7 +20,9 @@ class PyScriptingBackend
 {
 public:
   PyScriptingBackend(std::filesystem::path script_filepath, API::EventHub& event_hub, API::Gui& gui,
-                     API::GCManip& gc_manip, API::WiiButtonsManip& wii_buttons_manip, API::WiiIRManip& wii_ir_manip);
+                     API::GCManip& gc_manip, API::WiiButtonsManip& wii_buttons_manip,
+                     API::WiiIRManip& wii_ir_manip,
+                     API::NunchuckButtonsManip& nunchuck_buttons_manip);
   ~PyScriptingBackend();
   static PyScriptingBackend* GetCurrent();
   API::EventHub* GetEventHub();
@@ -28,6 +30,7 @@ public:
   API::GCManip* GetGCManip();
   API::WiiButtonsManip* GetWiiButtonsManip();
   API::WiiIRManip* GetWiiIRManip();
+  API::NunchuckButtonsManip* GetNunchuckButtonsManip();
   void AddCleanupFunc(std::function<void()> cleanup_func);
 
   // this class somewhat is a wrapper around a python interpreter state,
@@ -50,6 +53,7 @@ private:
   API::GCManip& m_gc_manip;
   API::WiiButtonsManip& m_wii_buttons_manip;
   API::WiiIRManip& m_wii_ir_manip;
+  API::NunchuckButtonsManip& m_nunchuck_buttons_manip;
   std::vector<std::function<void()>> m_cleanups;
 };
 

--- a/Source/Core/Scripting/ScriptingEngine.cpp
+++ b/Source/Core/Scripting/ScriptingEngine.cpp
@@ -19,7 +19,7 @@ ScriptingBackend::ScriptingBackend(std::filesystem::path script_filepath)
   // If there was support for multiple backend, a fitting one could be
   // detected based on the script file's extension for example.
   m_state = new PyScripting::PyScriptingBackend(script_filepath, API::GetEventHub(), API::GetGui(),
-                                                API::GetGCManip(), API::GetWiiButtonsManip(), API::GetWiiIRManip());
+                                                API::GetGCManip(), API::GetWiiButtonsManip(), API::GetWiiIRManip(), API::GetNunchuckButtonsManip());
 }
 
 ScriptingBackend::~ScriptingBackend() {


### PR DESCRIPTION
- Adds two new API functions to get/set nunchuck stick and buttons
- controller.get_nunchuck_buttons and controller.set_nunchuck_buttons
- arguments to be updated in stub in next PR
- Remove unused arguments from Movie::PlayWiimote

Note: I could not find a reliable way to retrieve the current state of the nunchuck, so as an alternative I've opted to (if the controller is active) save the state of the nunchuck to the scripting module-managed class for the nunchuck.