### PR TITLE
Make controller default Connected when setting inputs

### DIFF
--- a/Source/Core/Scripting/Python/Modules/controllermodule.cpp
+++ b/Source/Core/Scripting/Python/Modules/controllermodule.cpp
@@ -91,7 +91,7 @@ static GCPadStatus GCPadStatusFromPyDict(PyObject* dict) {
   u8 analog_b = py_analog_b == nullptr ? 0 : PyLong_AsUnsignedLong(py_analog_b);
 
   PyObject* py_connected = PyDict_GetItemString(dict, "Connected");
-  bool connected = py_connected != nullptr && PyObject_IsTrue(py_connected);
+  bool connected = py_connected == nullptr || PyObject_IsTrue(py_connected);
 
   GCPadStatus status;
   status.button = (button_left ? PAD_BUTTON_LEFT : 0) | (button_right ? PAD_BUTTON_RIGHT : 0) |


### PR DESCRIPTION
If we're passing inputs via set_gc_buttons, we obviously want the controller to be enabled. Current behavior is that if 'Connected' is not specified in the dictionary, then it will be set to False. This is silly. Get rid of this.