### PR TITLE
Add feature to lock game screen to right side

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -231,6 +231,8 @@ const Info<int> MAIN_RENDER_WINDOW_WIDTH{{System::Main, "Display", "RenderWindow
 const Info<int> MAIN_RENDER_WINDOW_HEIGHT{{System::Main, "Display", "RenderWindowHeight"}, 480};
 const Info<bool> MAIN_RENDER_WINDOW_AUTOSIZE{{System::Main, "Display", "RenderWindowAutoSize"},
                                              false};
+const Info<bool> MAIN_RENDER_WINDOW_LOCK_RIGHT{{System::Main, "Display", "RenderWindowLockRight"},
+                                             true};
 const Info<bool> MAIN_KEEP_WINDOW_ON_TOP{{System::Main, "Display", "KeepWindowOnTop"}, false};
 const Info<bool> MAIN_DISABLE_SCREENSAVER{{System::Main, "Display", "DisableScreenSaver"}, true};
 

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -167,6 +167,7 @@ extern const Info<int> MAIN_RENDER_WINDOW_YPOS;
 extern const Info<int> MAIN_RENDER_WINDOW_WIDTH;
 extern const Info<int> MAIN_RENDER_WINDOW_HEIGHT;
 extern const Info<bool> MAIN_RENDER_WINDOW_AUTOSIZE;
+extern const Info<bool> MAIN_RENDER_WINDOW_LOCK_RIGHT;
 extern const Info<bool> MAIN_KEEP_WINDOW_ON_TOP;
 extern const Info<bool> MAIN_DISABLE_SCREENSAVER;
 

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -92,6 +92,8 @@ void GeneralWidget::CreateWidgets()
       new GraphicsBool(tr("Log Render Time to File"), Config::GFX_LOG_RENDER_TIME_TO_FILE);
   m_autoadjust_window_size =
       new GraphicsBool(tr("Auto-Adjust Window Size"), Config::MAIN_RENDER_WINDOW_AUTOSIZE);
+  m_lock_window_to_right =
+      new GraphicsBool(tr("Lock Window to Right"), Config::MAIN_RENDER_WINDOW_LOCK_RIGHT);
   m_show_messages =
       new GraphicsBool(tr("Show NetPlay Messages"), Config::GFX_SHOW_NETPLAY_MESSAGES);
   m_render_main_window = new GraphicsBool(tr("Render to Main Window"), Config::MAIN_RENDER_TO_MAIN);
@@ -104,8 +106,10 @@ void GeneralWidget::CreateWidgets()
   m_options_layout->addWidget(m_render_main_window, 1, 0);
   m_options_layout->addWidget(m_autoadjust_window_size, 1, 1);
 
-  m_options_layout->addWidget(m_show_messages, 2, 0);
-  m_options_layout->addWidget(m_show_ping, 2, 1);
+  m_options_layout->addWidget(m_lock_window_to_right, 2, 0);
+  m_options_layout->addWidget(m_show_messages, 2, 1);
+
+  m_options_layout->addWidget(m_show_ping, 3, 0);
 
   // Other
   auto* shader_compilation_box = new QGroupBox(tr("Shader Compilation"));

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -53,6 +53,7 @@ private:
   GraphicsBool* m_show_ping;
   GraphicsBool* m_log_render_time;
   GraphicsBool* m_autoadjust_window_size;
+  GraphicsBool* m_lock_window_to_right;
   GraphicsBool* m_show_messages;
   GraphicsBool* m_render_main_window;
   std::array<GraphicsRadioInt*, 4> m_shader_compilation_mode{};

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -875,7 +875,14 @@ void Renderer::UpdateDrawRectangle()
   draw_width = std::ceil(draw_width) - static_cast<int>(std::ceil(draw_width)) % 4;
   draw_height = std::ceil(draw_height) - static_cast<int>(std::ceil(draw_height)) % 4;
 
-  m_target_rectangle.left = static_cast<int>(std::round(win_width / 2.0 - draw_width / 2.0));
+  // Malleo - New feature to lock game render to right side of render widget.
+  // This will maximize the amount of contiguous black space because
+  // it's not split between both sides of game render.
+  // This is really only useful when scripts send text to the GUI.
+  float width_div = Config::Get(Config::MAIN_RENDER_WINDOW_LOCK_RIGHT) ? 1.0 : 2.0;
+
+  m_target_rectangle.left =
+      static_cast<int>(std::round(win_width / width_div - draw_width / width_div));
   m_target_rectangle.top = static_cast<int>(std::round(win_height / 2.0 - draw_height / 2.0));
   m_target_rectangle.right = m_target_rectangle.left + static_cast<int>(draw_width);
   m_target_rectangle.bottom = m_target_rectangle.top + static_cast<int>(draw_height);


### PR DESCRIPTION
This is a feature I have in my custom build of Dolphin that I figure should be added here.

I hate obstructing my game feed with script info display. I prefer to have it written over the black portions of the game window. To maximize the amount of black space, I've added a toggleable config setting which will either center-align the game render or right-align it.

I have the default set to ON, so it will be locked to right side of screen.

Off: 
![image](https://user-images.githubusercontent.com/16770560/225969973-d5a69daa-9955-474d-8729-9e9b410c85d5.png)

On:
![image](https://user-images.githubusercontent.com/16770560/225970004-faf5d647-d128-4c10-935f-37ca537125b8.png)
