### PR TITLE
Script GUI changes

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -292,7 +292,7 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
 
   if (script.has_value())
   {
-    m_scripting_widget->AddScript(script.value());
+    m_scripting_widget->AddScript(script.value(), true);
   }
 }
 

--- a/Source/Core/DolphinQt/Scripting/ScriptingWidget.cpp
+++ b/Source/Core/DolphinQt/Scripting/ScriptingWidget.cpp
@@ -26,7 +26,7 @@ ScriptingWidget::ScriptingWidget(QWidget* parent)
 
   // actions
   QPushButton* button_add_new = new QPushButton(tr("Add New Script"));
-  QPushButton* button_reload_selected = new QPushButton(tr("Reload Selected Script"));
+  QPushButton* button_reload_selected = new QPushButton(tr("Restart Selected Script"));
   QPushButton* button_remove_selected = new QPushButton(tr("Remove Selected Script"));
   QHBoxLayout* actions_layout = new QHBoxLayout;
   actions_layout->addWidget(button_add_new);
@@ -40,13 +40,13 @@ ScriptingWidget::ScriptingWidget(QWidget* parent)
   m_table_view = new QTableView();
   m_table_view->setModel(m_scripts_model);
   m_table_view->horizontalHeader()->setStretchLastSection(true);
-  m_table_view->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
+  m_table_view->horizontalHeader()->hide();
   m_table_view->verticalHeader()->hide();
   m_table_view->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_table_view->setSelectionMode(QAbstractItemView::SingleSelection);
 
   // put in group box
-  QGroupBox* scripts_group = new QGroupBox(tr("Running scripts"));
+  QGroupBox* scripts_group = new QGroupBox(tr("Loaded Scripts"));
   QVBoxLayout* scripts_layout = new QVBoxLayout;
   scripts_group->setLayout(scripts_layout);
   scripts_layout->addWidget(m_table_view);
@@ -63,7 +63,7 @@ ScriptingWidget::ScriptingWidget(QWidget* parent)
 
   connect(button_add_new, &QPushButton::clicked, this, &ScriptingWidget::AddNewScript);
   connect(button_reload_selected, &QPushButton::clicked, this,
-          &ScriptingWidget::ReloadSelectedScript);
+          &ScriptingWidget::RestartSelectedScript);
   connect(button_remove_selected, &QPushButton::clicked, this,
           &ScriptingWidget::RemoveSelectedScript);
 }
@@ -86,11 +86,11 @@ void ScriptingWidget::AddNewScript()
   }
 }
 
-void ScriptingWidget::ReloadSelectedScript()
+void ScriptingWidget::RestartSelectedScript()
 {
   for (const QModelIndex& q_index : m_table_view->selectionModel()->selectedRows())
   {
-    m_scripts_model->Reload(q_index.row());
+    m_scripts_model->Restart(q_index.row());
   }
 }
 
@@ -102,7 +102,7 @@ void ScriptingWidget::RemoveSelectedScript()
   }
 }
 
-void ScriptingWidget::AddScript(std::string filename)
+void ScriptingWidget::AddScript(std::string filename, bool enabled /* = false */)
 {
-  m_scripts_model->Add(filename);
+  m_scripts_model->Add(filename, enabled);
 }

--- a/Source/Core/DolphinQt/Scripting/ScriptingWidget.h
+++ b/Source/Core/DolphinQt/Scripting/ScriptingWidget.h
@@ -15,9 +15,9 @@ class ScriptingWidget : public QDockWidget
 public:
   ScriptingWidget(QWidget* parent = nullptr);
   void AddNewScript();
-  void ReloadSelectedScript();
+  void RestartSelectedScript();
   void RemoveSelectedScript();
-  void AddScript(std::string filename);
+  void AddScript(std::string filename, bool enabled = false);
 
 private:
   ScriptsListModel* m_scripts_model;

--- a/Source/Core/DolphinQt/Scripting/ScriptsListModel.h
+++ b/Source/Core/DolphinQt/Scripting/ScriptsListModel.h
@@ -11,7 +11,8 @@
 struct Script
 {
   std::string filename;
-  Scripting::ScriptingBackend backend;
+  Scripting::ScriptingBackend* backend;
+  bool enabled;
 };
 
 class ScriptsListModel : public QAbstractListModel
@@ -22,13 +23,11 @@ public:
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   int columnCount(const QModelIndex &parent = QModelIndex()) const override;
   QVariant data(const QModelIndex &index, int role) const override;
-  QVariant headerData(int section, Qt::Orientation orientation,
-                      int role = Qt::DisplayRole) const override;
-  bool insertRows(int position, int rows, const QModelIndex &index = QModelIndex()) override;
-  bool removeRows(int position, int rows, const QModelIndex &index = QModelIndex()) override;
+  bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
 
-  void Add(std::string filename);
-  void Reload(int index);
+  void Add(std::string filename, bool enabled = false);
+  void Restart(int index);
   void Remove(int index);
 
 private:


### PR DESCRIPTION
- Primary goal is new toggle functionality, to determine whether or not a script is running
- Get rid of Name header as it serves no purpose really
- Change table label from Running scripts to Loaded scripts. This isn't entirely truthful, but it makes more sense since now they aren't always running
- Fix improper convention when adding/removing rows to the model

If we want to change name formatting since full URL looks ugly, then let's worry about that in a different PR after some more discussion.
![image](https://user-images.githubusercontent.com/16770560/227426428-6671bc21-67da-4bb6-a3b4-8078aa348277.png)
