### PR TITLE
Script to lint and type-check python-stubs

### DIFF
--- a/Tools/lint-python-stubs.sh
+++ b/Tools/lint-python-stubs.sh
@@ -4,14 +4,15 @@
 # N:    pep8-naming
 # Q:    flake8-quotes
 # D:    pydocstyle
-# D1:   pydocstyle Missing doctring
-# D203: pydocstyle: one-blank-line-before-class
-# D205: pydocstyle: blank-line-after-summary
-# D212: pydocstyle: multi-line-summary-first-line
-# D401: pydocstyle: non-imperative-mood
+# D1:     pydocstyle: Missing doctring
+# PYI021: flake8-pyi: docstring-in-stub
+# D203:   pydocstyle: one-blank-line-before-class
+# D205:   pydocstyle: blank-line-after-summary
+# D212:   pydocstyle: multi-line-summary-first-line
+# D401:   pydocstyle: non-imperative-mood
 echo
 echo Run Ruff
-ruff python-stubs --fix --extend-select=PYI,N,Q,D --ignore=D1,D203,D205,D212,D401
+ruff python-stubs --fix --extend-select=PYI,N,Q,D --ignore=PYI021,D1,D203,D205,D212,D401
 
 echo
 echo Run Black

--- a/Tools/lint-python-stubs.sh
+++ b/Tools/lint-python-stubs.sh
@@ -1,0 +1,27 @@
+# Run `pip install -r requirements-tests.txt` to install dependencies first
+
+# PYI:  flake8-pyi
+# N:    pep8-naming
+# Q:    flake8-quotes
+# D:    pydocstyle
+# D1:   pydocstyle Missing doctring
+# D203: pydocstyle: one-blank-line-before-class
+# D205: pydocstyle: blank-line-after-summary
+# D212: pydocstyle: multi-line-summary-first-line
+# D401: pydocstyle: non-imperative-mood
+echo
+echo Run Ruff
+ruff python-stubs --fix --extend-select=PYI,N,Q,D --ignore=D1,D203,D205,D212,D401
+
+echo
+echo Run Black
+black python-stubs --line-length=100
+
+echo
+echo Run mypy
+mypy python-stubs --strict --python-version=3.8
+
+# You *can* install the python wrapper using pip, but it is recommended to install node directly instead
+echo
+echo Run Pyright
+npx pyright@1.1.300 python-stubs --pythonversion=3.8.5

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
 black>=23.1.0
-ruff>=0.0.259
+ruff>=0.0.261
 mypy>=1.0.0
 typing-extensions

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,4 @@
+black>=23.1.0
+ruff>=0.0.259
+mypy>=1.0.0
+typing-extensions


### PR DESCRIPTION
A very simple, config-less script to format, lint and type-check the python stubs. The same could be expanded for the entire project (but then I'd use a `project.toml` config file)
I added a `requirements` file with the necessary dependencies for testing.

The [Pyright python wrapper](https://pypi.org/project/pyright/) just installs node and highjacks the Pyright command, may as well install node yourself using your favorite package manager (or downloading the installer from their website).
The `npx` command checks if the package is already installed at that specific version, (in local and global `node_modules`), if not, it installs it globally then executes.

Of course linting will fail until #16 is merged.