### PR TITLE
TAS Input Window Adjustments

### DIFF
--- a/Source/Core/DolphinQt/QtUtils/AspectRatioWidget.cpp
+++ b/Source/Core/DolphinQt/QtUtils/AspectRatioWidget.cpp
@@ -13,6 +13,8 @@ AspectRatioWidget::AspectRatioWidget(QWidget* widget, float width, float height,
     : QWidget(parent), m_ar_width(width), m_ar_height(height)
 {
   m_layout = new QBoxLayout(QBoxLayout::LeftToRight, this);
+  m_layout->setSpacing(0);
+  m_layout->setContentsMargins(0, 0, 0, 0);
 
   // add spacer, then your widget, then spacer
   m_layout->addItem(new QSpacerItem(0, 0));

--- a/Source/Core/DolphinQt/TAS/GCTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/GCTASInputWindow.cpp
@@ -30,58 +30,88 @@ GCTASInputWindow::GCTASInputWindow(QWidget* parent, int num) : TASInputWindow(pa
   top_layout->addWidget(m_main_stick_box);
   top_layout->addWidget(m_c_stick_box);
 
+  CreateTriggersBox();
+  CreateButtonsBox();
+
+  // Combine triggers, buttons, and settings into a single row layout
+  auto* trigger_and_buttons_layout = new QHBoxLayout();
+  trigger_and_buttons_layout->addWidget(m_triggers_box);
+  trigger_and_buttons_layout->addWidget(m_buttons_box);
+  trigger_and_buttons_layout->addWidget(m_settings_box);
+  trigger_and_buttons_layout->setAlignment(m_triggers_box, Qt::AlignTop);
+  trigger_and_buttons_layout->setAlignment(m_buttons_box, Qt::AlignTop);
+  trigger_and_buttons_layout->setAlignment(m_settings_box, Qt::AlignTop);
+
+  auto* layout = new QVBoxLayout;
+  layout->addLayout(top_layout);
+  layout->addLayout(trigger_and_buttons_layout);
+
+  setLayout(layout);
+
+  setMinimumWidth(430);
+  setMinimumHeight(375);
+}
+
+void GCTASInputWindow::CreateTriggersBox()
+{
   m_triggers_box = new QGroupBox(tr("Triggers"));
 
-  auto* l_trigger_layout =
-      CreateSliderValuePairLayout(tr("Left"), m_l_trigger_value, 0, 255, Qt::Key_N, m_triggers_box);
-  auto* r_trigger_layout = CreateSliderValuePairLayout(tr("Right"), m_r_trigger_value, 0, 255,
-                                                       Qt::Key_M, m_triggers_box);
+  auto* l_trigger_layout = new QVBoxLayout();
+  m_l_trigger_value =
+      CreateSliderValuePair(l_trigger_layout, 0, 255, Qt::Key_N, Qt::Vertical, m_triggers_box);
 
-  auto* triggers_layout = new QVBoxLayout;
+  auto* r_trigger_layout = new QVBoxLayout();
+  m_r_trigger_value =
+      CreateSliderValuePair(r_trigger_layout, 0, 255, Qt::Key_M, Qt::Vertical, m_triggers_box);
+
+  auto* triggers_layout = new QHBoxLayout;
   triggers_layout->addLayout(l_trigger_layout);
   triggers_layout->addLayout(r_trigger_layout);
   m_triggers_box->setLayout(triggers_layout);
+}
+
+void GCTASInputWindow::CreateButtonsBox()
+{
+  m_buttons_box = new QGroupBox(tr("Buttons"));
 
   m_a_button = CreateButton(QStringLiteral("&A"));
   m_b_button = CreateButton(QStringLiteral("&B"));
   m_x_button = CreateButton(QStringLiteral("&X"));
   m_y_button = CreateButton(QStringLiteral("&Y"));
-  m_z_button = CreateButton(QStringLiteral("&Z"));
   m_l_button = CreateButton(QStringLiteral("&L"));
+  m_z_button = CreateButton(QStringLiteral("&Z"));
   m_r_button = CreateButton(QStringLiteral("&R"));
-  m_start_button = CreateButton(QStringLiteral("&START"));
-  m_left_button = CreateButton(QStringLiteral("L&eft"));
-  m_up_button = CreateButton(QStringLiteral("&Up"));
-  m_down_button = CreateButton(QStringLiteral("&Down"));
-  m_right_button = CreateButton(QStringLiteral("R&ight"));
+  m_start_button = CreateButton(QStringLiteral("&S"));
+
+  m_left_button = CreateButton(QStringLiteral("L"));
+  m_up_button = CreateButton(QStringLiteral("U"));
+  m_down_button = CreateButton(QStringLiteral("D"));
+  m_right_button = CreateButton(QStringLiteral("R"));
 
   auto* buttons_layout = new QGridLayout;
   buttons_layout->addWidget(m_a_button, 0, 0);
   buttons_layout->addWidget(m_b_button, 0, 1);
   buttons_layout->addWidget(m_x_button, 0, 2);
   buttons_layout->addWidget(m_y_button, 0, 3);
-  buttons_layout->addWidget(m_z_button, 0, 4);
-  buttons_layout->addWidget(m_l_button, 0, 5);
-  buttons_layout->addWidget(m_r_button, 0, 6);
+  buttons_layout->addWidget(m_l_button, 1, 0);
+  buttons_layout->addWidget(m_z_button, 1, 1);
+  buttons_layout->addWidget(m_r_button, 1, 2);
+  buttons_layout->addWidget(m_start_button, 1, 3);
 
-  buttons_layout->addWidget(m_start_button, 1, 0);
-  buttons_layout->addWidget(m_left_button, 1, 1);
-  buttons_layout->addWidget(m_up_button, 1, 2);
-  buttons_layout->addWidget(m_down_button, 1, 3);
-  buttons_layout->addWidget(m_right_button, 1, 4);
+  auto* dpad_layout = new QGridLayout;
+  dpad_layout->addWidget(m_left_button, 1, 0);
+  dpad_layout->addWidget(m_up_button, 0, 1);
+  dpad_layout->addWidget(m_down_button, 2, 1);
+  dpad_layout->addWidget(m_right_button, 1, 2);
+  dpad_layout->setVerticalSpacing(0);
+  dpad_layout->setHorizontalSpacing(25);
 
-  buttons_layout->addItem(new QSpacerItem(1, 1, QSizePolicy::Expanding), 0, 7);
+  auto* combined_layout = new QVBoxLayout();
+  combined_layout->setAlignment(Qt::AlignTop);
+  combined_layout->addLayout(buttons_layout);
+  combined_layout->addLayout(dpad_layout);
 
-  m_buttons_box = new QGroupBox(tr("Buttons"));
-  m_buttons_box->setLayout(buttons_layout);
-
-  auto* layout = new QVBoxLayout;
-  layout->addLayout(top_layout);
-  layout->addWidget(m_triggers_box);
-  layout->addWidget(m_buttons_box);
-  layout->addWidget(m_settings_box);
-
-  setLayout(layout);
+  m_buttons_box->setLayout(combined_layout);
 }
 
 void GCTASInputWindow::GetValues(GCPadStatus* pad)

--- a/Source/Core/DolphinQt/TAS/GCTASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/GCTASInputWindow.h
@@ -18,6 +18,9 @@ public:
   void GetValues(GCPadStatus* pad);
 
 private:
+  void CreateTriggersBox();
+  void CreateButtonsBox();
+
   TASCheckBox* m_a_button;
   TASCheckBox* m_b_button;
   TASCheckBox* m_x_button;

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -32,22 +32,31 @@ TASInputWindow::TASInputWindow(QWidget* parent) : QDialog(parent)
 
   QGridLayout* settings_layout = new QGridLayout;
 
-  m_use_controller = new QCheckBox(QStringLiteral("Enable Controller Inpu&t"));
+  m_use_controller = new QCheckBox(QStringLiteral("Enable Controller"));
   m_use_controller->setToolTip(tr("Warning: Analog inputs may reset to controller values at "
                                   "random. In some cases this can be fixed by adding a deadzone."));
   settings_layout->addWidget(m_use_controller, 0, 0, 1, 2);
 
-  QLabel* turbo_press_label = new QLabel(tr("Duration of Turbo Button Press (frames):"));
+  auto* turbo_box = new QGroupBox(tr("Turbo"));
+
+  settings_layout->addWidget(turbo_box, 1, 0);
+
+  QGridLayout* turbo_layout = new QGridLayout;
+
+  QLabel* turbo_press_label = new QLabel(tr("Press:"));
   m_turbo_press_frames = new QSpinBox();
   m_turbo_press_frames->setMinimum(1);
-  settings_layout->addWidget(turbo_press_label, 1, 0);
-  settings_layout->addWidget(m_turbo_press_frames, 1, 1);
+  turbo_layout->addWidget(turbo_press_label, 0, 0);
+  turbo_layout->addWidget(m_turbo_press_frames, 0, 1);
 
-  QLabel* turbo_release_label = new QLabel(tr("Duration of Turbo Button Release (frames):"));
+  QLabel* turbo_release_label = new QLabel(tr("Release:"));
   m_turbo_release_frames = new QSpinBox();
   m_turbo_release_frames->setMinimum(1);
-  settings_layout->addWidget(turbo_release_label, 2, 0);
-  settings_layout->addWidget(m_turbo_release_frames, 2, 1);
+
+  turbo_layout->addWidget(turbo_release_label, 1, 0);
+  turbo_layout->addWidget(m_turbo_release_frames, 1, 1);
+
+  turbo_box->setLayout(turbo_layout);
 
   m_settings_box = new QGroupBox(tr("Settings"));
   m_settings_box->setLayout(settings_layout);
@@ -90,11 +99,12 @@ QGroupBox* TASInputWindow::CreateStickInputs(QString name, QSpinBox*& x_value, Q
   auto* y_layout = new QVBoxLayout;
   y_value =
       CreateSliderValuePair(y_layout, y_default, max_y, y_shortcut_key_sequence, Qt::Vertical, box);
-  y_value->setMaximumWidth(60);
 
   auto* visual = new StickWidget(this, max_x, max_y);
   visual->SetX(x_default);
   visual->SetY(y_default);
+  visual->setMinimumHeight(100);
+  visual->setMinimumWidth(100);
 
   connect(x_value, qOverload<int>(&QSpinBox::valueChanged), visual, &StickWidget::SetX);
   connect(y_value, qOverload<int>(&QSpinBox::valueChanged), visual, &StickWidget::SetY);
@@ -111,6 +121,8 @@ QGroupBox* TASInputWindow::CreateStickInputs(QString name, QSpinBox*& x_value, Q
   layout->addLayout(x_layout);
   layout->addLayout(visual_layout);
   box->setLayout(layout);
+
+  box->setMinimumWidth(150);
 
   return box;
 }
@@ -143,6 +155,8 @@ QSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, int default_
   auto* value = new QSpinBox();
   value->setRange(0, 99999);
   value->setValue(default_);
+  value->setButtonSymbols(QAbstractSpinBox::NoButtons);
+  value->setMaximumWidth(40);
   connect(value, qOverload<int>(&QSpinBox::valueChanged), [value, max](int i) {
     if (i > max)
       value->setValue(max);
@@ -166,6 +180,8 @@ QSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, int default_
   layout->addWidget(value);
   if (orientation == Qt::Vertical)
     layout->setAlignment(slider, Qt::AlignRight);
+
+  slider->setMinimumHeight(10);
 
   return value;
 }


### PR DESCRIPTION
Before:--------------------------------------------------------------After:
<img src="https://user-images.githubusercontent.com/16770560/229375133-24ad9180-6beb-4610-9af4-8ba8e5f33f9a.png" width="300"> <img src="https://user-images.githubusercontent.com/16770560/229375139-9f9f4419-6712-4d5b-a667-b467b1e64c94.png" width="300">

This changes TAS Input to *mostly* match the window style from DolphinWx. The most important piece, in my opinion, is that it eliminates the unnecessarily excessive whitespace between the stick widget and the sliders.