### PR TITLE
Allow hotkeys when TAS Input is window-of-focus

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -157,6 +157,11 @@ bool Host_RendererHasFullFocus()
   return true;
 }
 
+bool Host_TASInputHasFullFocus()
+{
+    return false;
+}
+
 bool Host_RendererIsFullscreen()
 {
   return false;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -1154,10 +1154,11 @@ void UpdateInputGate(bool require_focus, bool require_full_focus)
 {
   // If the user accepts background input, controls should pass even if an on screen interface is on
   const bool focus_passes =
-      !require_focus || (Host_RendererHasFocus() && !Host_UIBlocksControllerState());
+      !require_focus || Host_RendererHasFocus() || Host_TASInputHasFullFocus();
   // Ignore full focus if we don't require basic focus
   const bool full_focus_passes =
-      !require_focus || !require_full_focus || (focus_passes && Host_RendererHasFullFocus());
+      !require_focus || !require_full_focus ||
+      (focus_passes && (Host_RendererHasFullFocus() || Host_TASInputHasFullFocus()));
   ControlReference::SetInputGate(focus_passes && full_focus_passes);
 }
 

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -53,6 +53,7 @@ bool Host_UIBlocksControllerState();
 bool Host_RendererHasFocus();
 bool Host_RendererHasFullFocus();
 bool Host_RendererIsFullscreen();
+bool Host_TASInputHasFullFocus();
 
 void Host_Message(HostMessageID id);
 void Host_NotifyMapLoaded();

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -110,6 +110,11 @@ bool Host_RendererIsFullscreen()
   return s_platform->IsWindowFullscreen();
 }
 
+bool Host_TASInputHasFullFocus()
+{
+  return false;
+}
+
 void Host_YieldToUI()
 {
 }

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -126,7 +126,7 @@ static void RunWithGPUThreadInactive(std::function<void()> f)
   }
 }
 
-bool Host::GetRenderFocus()
+bool Host::GetRenderFocus() const
 {
 #ifdef _WIN32
   // Unfortunately Qt calls SetRenderFocus() with a slight delay compared to what we actually need
@@ -139,7 +139,7 @@ bool Host::GetRenderFocus()
 #endif
 }
 
-bool Host::GetRenderFullFocus()
+bool Host::GetRenderFullFocus() const
 {
   return m_render_full_focus;
 }
@@ -161,7 +161,17 @@ void Host::SetRenderFullFocus(bool focus)
   m_render_full_focus = focus;
 }
 
-bool Host::GetGBAFocus()
+bool Host::GetTASInputFullFocus() const
+{
+  return m_tas_input_full_focus;
+}
+
+void Host::SetTASInputFullFocus(bool focus)
+{
+  m_tas_input_full_focus = focus;
+}
+
+bool Host::GetGBAFocus() const
 {
 #ifdef HAS_LIBMGBA
   return qobject_cast<GBAWidget*>(QApplication::activeWindow()) != nullptr;
@@ -170,7 +180,7 @@ bool Host::GetGBAFocus()
 #endif
 }
 
-bool Host::GetRenderFullscreen()
+bool Host::GetRenderFullscreen() const
 {
   return m_render_fullscreen;
 }
@@ -235,6 +245,11 @@ bool Host_RendererHasFullFocus()
 bool Host_RendererIsFullscreen()
 {
   return Host::GetInstance()->GetRenderFullscreen();
+}
+
+bool Host_TASInputHasFullFocus()
+{
+  return Host::GetInstance()->GetTASInputFullFocus();
 }
 
 void Host_YieldToUI()

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -24,16 +24,18 @@ public:
   void DeclareAsHostThread();
   bool IsHostThread();
 
-  bool GetRenderFocus();
-  bool GetRenderFullFocus();
-  bool GetRenderFullscreen();
-  bool GetGBAFocus();
+  bool GetRenderFocus() const;
+  bool GetRenderFullFocus() const;
+  bool GetRenderFullscreen() const;
+  bool GetTASInputFullFocus() const;
+  bool GetGBAFocus() const;
 
   void SetMainWindowHandle(void* handle);
   void SetRenderHandle(void* handle);
   void SetRenderFocus(bool focus);
   void SetRenderFullFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);
+  void SetTASInputFullFocus(bool focus);
   void ResizeSurface(int new_width, int new_height);
   void RequestNotifyMapLoaded();
 
@@ -53,4 +55,5 @@ private:
   std::atomic<bool> m_render_focus{false};
   std::atomic<bool> m_render_full_focus{false};
   std::atomic<bool> m_render_fullscreen{false};
+  std::atomic<bool> m_tas_input_full_focus{false};
 };

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1809,6 +1809,7 @@ void MainWindow::ShowTASInput()
       m_gc_tas_input_windows[i]->show();
       m_gc_tas_input_windows[i]->raise();
       m_gc_tas_input_windows[i]->activateWindow();
+      m_gc_tas_input_windows[i]->setFocus();
     }
   }
 
@@ -1820,6 +1821,7 @@ void MainWindow::ShowTASInput()
       m_wii_tas_input_windows[i]->show();
       m_wii_tas_input_windows[i]->raise();
       m_wii_tas_input_windows[i]->activateWindow();
+      m_wii_tas_input_windows[i]->setFocus();
     }
   }
 }

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -16,6 +16,7 @@
 
 #include "Common/CommonTypes.h"
 
+#include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/AspectRatioWidget.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/Resources.h"
@@ -234,4 +235,14 @@ void TASInputWindow::GetSpinBoxU16(QSpinBox* spin, u16& controller_value)
   }
 
   controller_value = spin->value();
+}
+
+void TASInputWindow::focusOutEvent(QFocusEvent* event)
+{
+  Host::GetInstance()->SetTASInputFullFocus(false);
+}
+
+void TASInputWindow::focusInEvent(QFocusEvent* event)
+{
+  Host::GetInstance()->SetTASInputFullFocus(true);
 }

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.h
@@ -26,6 +26,9 @@ public:
   int GetTurboReleaseFrames() const;
 
 protected:
+  void focusOutEvent(QFocusEvent* event) override;
+  void focusInEvent(QFocusEvent* event) override;
+
   TASCheckBox* CreateButton(const QString& name);
   QGroupBox* CreateStickInputs(QString name, QSpinBox*& x_value, QSpinBox*& y_value, u16 max_x,
                                u16 max_y, Qt::Key x_shortcut_key, Qt::Key y_shortcut_key);
@@ -46,6 +49,7 @@ protected:
   QSpinBox* m_turbo_release_frames;
 
 private:
+
   std::map<TASCheckBox*, bool> m_checkbox_set_by_controller;
   std::map<QSpinBox*, u8> m_spinbox_most_recent_values_u8;
   std::map<QSpinBox*, u8> m_spinbox_most_recent_values_u16;

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -46,6 +46,10 @@ bool Host_RendererIsFullscreen()
 {
   return false;
 }
+bool Host_TASInputHasFullFocus()
+{
+  return false;
+}
 void Host_YieldToUI()
 {
 }

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -50,6 +50,10 @@ bool Host_RendererIsFullscreen()
 {
   return false;
 }
+bool Host_TASInputHasFullFocus()
+{
+  return false;
+}
 void Host_YieldToUI()
 {
 }


### PR DESCRIPTION
These changes aim to allow hotkeys to be processed when TAS Input is the window of focus, regardless of whether or not the "Hotkeys Require Window Focus" hotkey is disabled/enabled. Previously, the only way you could frame advance with TAS Input is if you were ALSO able to frame advance when Discord, for example, is open. This is not optimal behavior, because we don't want random hotkeys to fire off by default when we are typing out Discord messages for example.

Note that these changes remove the use of the Host_UIBlocksControllerState() function, because of an edge case discovered with my changes. If you hold down a hotkey and switch from TAS Input to the game render widget, ImGUI can end up in a state where it will permanently not process keyboard inputs. I'm not quite sure what the reason for this is, but the regression is isolated to just hotkey processing. The Host_UIBlocksControllerState() function was introduced solely to prevent controller input processing when the user is typing in the Netplay UI chat (see https://github.com/dolphin-emu/dolphin/pull/7903). As such, I'm not concerned with regressing this functionality, as no one will use Netplay with this Dolphin version.

Alternatively, additional investigation may lead to a cleaner way to solve ImGUI setting WantCaptureKeyboard to false on window toggle. Please offer suggestions or thoughts if we want to pursue this route instead. I've tried spending time on this, but haven't found any leads...