### PR TITLE
DolphinQt: Limit TAS window stick signals/redraws

### DIFF
--- a/Source/Core/DolphinQt/TAS/IRWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/IRWidget.cpp
@@ -79,6 +79,9 @@ void IRWidget::mouseMoveEvent(QMouseEvent* event)
 
 void IRWidget::handleMouseEvent(QMouseEvent* event)
 {
+  u16 prev_x = m_x;
+  u16 prev_y = m_y;
+
   if (event->button() == Qt::RightButton)
   {
     m_x = std::round(ir_max_x / 2.);
@@ -94,7 +97,18 @@ void IRWidget::handleMouseEvent(QMouseEvent* event)
     m_y = std::max(0, std::min(static_cast<int>(ir_max_y), new_y));
   }
 
-  emit ChangedX(m_x);
-  emit ChangedY(m_y);
-  update();
+  bool changed = false;
+  if (prev_x != m_x)
+  {
+    emit ChangedX(m_x);
+    changed = true;
+  }
+  if (prev_y != m_y)
+  {
+    emit ChangedY(m_y);
+    changed = true;
+  }
+
+  if (changed)
+    update();
 }

--- a/Source/Core/DolphinQt/TAS/StickWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/StickWidget.cpp
@@ -92,6 +92,9 @@ void StickWidget::mouseMoveEvent(QMouseEvent* event)
 
 void StickWidget::handleMouseEvent(QMouseEvent* event)
 {
+  u16 prev_x = m_x;
+  u16 prev_y = m_y;
+
   if (event->button() == Qt::RightButton)
   {
     m_x = std::round(m_max_x / 2.);
@@ -107,7 +110,18 @@ void StickWidget::handleMouseEvent(QMouseEvent* event)
     m_y = std::max(0, std::min(static_cast<int>(m_max_y), new_y));
   }
 
-  emit ChangedX(m_x);
-  emit ChangedY(m_y);
-  update();
+  bool changed = false;
+  if (prev_x != m_x)
+  {
+    emit ChangedX(m_x);
+    changed = true;
+  }
+  if (prev_y != m_y)
+  {
+    emit ChangedY(m_y);
+    changed = true;
+  }
+
+  if (changed)
+    update();
 }


### PR DESCRIPTION
This appears to reduce window latency issues encountered when holding down frame advance and rotating the stick at the same time. It does not get rid of the latency, but definitely reduces it.