### PR TITLE
Config: Disable Dual Core by default

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -41,7 +41,7 @@ const Info<bool> MAIN_ACCURATE_CPU_CACHE{{System::Main, "Core", "AccurateCPUCach
 const Info<bool> MAIN_DSP_HLE{{System::Main, "Core", "DSPHLE"}, true};
 const Info<int> MAIN_MAX_FALLBACK{{System::Main, "Core", "MaxFallback"}, 100};
 const Info<int> MAIN_TIMING_VARIANCE{{System::Main, "Core", "TimingVariance"}, 40};
-const Info<bool> MAIN_CPU_THREAD{{System::Main, "Core", "CPUThread"}, true};
+const Info<bool> MAIN_CPU_THREAD{{System::Main, "Core", "CPUThread"}, false};
 const Info<bool> MAIN_SYNC_ON_SKIP_IDLE{{System::Main, "Core", "SyncOnSkipIdle"}, true};
 const Info<std::string> MAIN_DEFAULT_ISO{{System::Main, "Core", "DefaultISO"}, ""};
 const Info<bool> MAIN_ENABLE_CHEATS{{System::Main, "Core", "EnableCheats"}, false};


### PR DESCRIPTION
Considering that this fork is intended for TASes, it makes sense (to me) to set this default to false. When enabled, dual core is pretty much guaranteed to cause .dtm desyncs. Truth be told the only TAS-related instance where this setting doesn't matter is Mario Kart Wii, since we use the in-game ghost system. However, script reliability is also dependent on this setting being disabled. So I don't see any drawbacks here.