### PR TITLE
API: Fix timing of frame advance event firing

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -892,6 +892,7 @@ void Callback_FramePresented(double actual_emulation_speed)
 // Called from VideoInterface::Update (CPU thread) at emulated field boundaries
 void Callback_NewField(Core::System& system)
 {
+  OnFrameBegin();
   if (s_frame_step)
   {
     // To ensure that s_stop_frame_step is up to date, wait for the GPU thread queue to empty,

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -823,7 +823,6 @@ void VideoInterfaceManager::OutputField(FieldType field, u64 ticks)
 
 void VideoInterfaceManager::BeginField(FieldType field, u64 ticks)
 {
-  Core::OnFrameBegin();
   // Outputting the frame at the beginning of scanout reduces latency. This assumes the game isn't
   // going to change the VI registers while a frame is scanning out.
   if (Config::Get(Config::GFX_HACK_EARLY_XFB_OUTPUT))


### PR DESCRIPTION
The long awaited fix to issue https://github.com/TASLabz/dolphin/issues/12

Looks like we need to fire the frame advance event at a different point. Someone in Dolphin's Discord server pointed out that they have a fork which signals frame advance occurrences in `Callback_NewField`, and this seems to fix the issue. Note that this means we can now remove the hacky solution from pianoroll.py: https://github.com/TASLabz/mkw-scripts/blob/main/scripts/pianoroll_player.py