### PR TITLE
Qt: Prevent savestate load/save on empty filename

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1332,7 +1332,8 @@ void MainWindow::StateLoad()
   QString path =
       DolphinFileDialog::getOpenFileName(this, tr("Select a File"), QDir::currentPath(),
                                          tr("All Save States (*.sav *.s##);; All Files (*)"));
-  State::LoadFile(path.toStdString());
+  if (!path.isEmpty())
+    State::LoadFile(path.toStdString());
 }
 
 void MainWindow::StateSave()
@@ -1340,7 +1341,8 @@ void MainWindow::StateSave()
   QString path =
       DolphinFileDialog::getSaveFileName(this, tr("Select a File"), QDir::currentPath(),
                                          tr("All Save States (*.sav *.s##);; All Files (*)"));
-  State::SaveFile(path.toStdString());
+  if (!path.isEmpty())
+    State::SaveFile(path.toStdString());
 }
 
 void MainWindow::StateLoadSlot()


### PR DESCRIPTION
This fixes the following behavior I encountered.

Emulation > Save State > Save State to File. Close dialog without setting filename
Observe on-screen message "Saving state to " (no filepath given), and observe xxxxx.tmp file being created in main Dolphin directory
Repeat step 1 and 2 to observe more .tmp files being created
Start Movie Recording, repeat step 1 to now also see blank ".dtm" file present
Looks like Dolphin will always write savestate data to a temp file and then try to rename it. Ultimately when the provided filename is blank (because the QFileDialog was closed without the name being set) the rename will fail and the temp file will remain.

I figured this filename check should also be done for the load state scenario, as all this does is prevent a load failure in LoadAs().