### PR TITLE
ScriptingWidget improvements

### DIFF
--- a/Source/Core/DolphinQt/Scripting/ScriptingWidget.h
+++ b/Source/Core/DolphinQt/Scripting/ScriptingWidget.h
@@ -16,11 +16,14 @@ public:
   ScriptingWidget(QWidget* parent = nullptr);
   void PopulateScripts();
   void AddNewScript();
-  void RestartSelectedScript();
-  void RemoveSelectedScript();
+  void RestartSelectedScripts();
+  void RemoveSelectedScripts();
+  void ToggleSelectedScripts();
   void AddScript(std::string filename, bool enabled = false);
 
 private:
+  bool eventFilter(QObject* object, QEvent* event);
+
   ScriptsListModel* m_scripts_model;
   QTableView* m_table_view;
 };

--- a/Source/Core/DolphinQt/Scripting/ScriptsListModel.cpp
+++ b/Source/Core/DolphinQt/Scripting/ScriptsListModel.cpp
@@ -112,6 +112,7 @@ void ScriptsListModel::Restart(int index)
 void ScriptsListModel::Remove(int index)
 {
   beginRemoveRows(QModelIndex(), index, index);
+  delete Scripts::g_scripts[index].backend;
   Scripts::g_scripts.erase(Scripts::g_scripts.begin() + index);
   endRemoveRows();
 }


### PR DESCRIPTION
This addresses https://github.com/TASLabz/dolphin/issues/60 and https://github.com/TASLabz/dolphin/issues/52

New functionality:
- Removing a script that's enabled will cause the script to stop running (It would continue to run post-mortem before!)
- Allow multi-selecting of scripts in list
- Pressing delete key on selection of scripts will remove all scripts from the list (and stop and actively running ones)
- Pressing enter key on selection of scripts will toggle enable/disable them.