### PR TITLE
fix compile issues for newer versions of Visual Studio

### DIFF
--- a/Source/Core/Core/API/Events.h
+++ b/Source/Core/Core/API/Events.h
@@ -66,7 +66,6 @@ using ListenerFuncPtr = void (*)(const T&);
 template <typename T>
 struct ListenerID
 {
-  bool operator==(const ListenerID& other) { return other.value == value; }
   u64 value;
 };
 
@@ -106,7 +105,7 @@ public:
   {
     for (auto it = m_listener_pairs.begin(); it != m_listener_pairs.end(); ++it)
     {
-      if (it->first == listener_id)
+      if (it->first.value == listener_id.value)
       {
         m_listener_pairs.erase(it);
         return true;


### PR DESCRIPTION
This addresses [C2666](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c2666?view=msvc-170) when using the latest MSVC version.

This is cherry-picked from felk, who I observe had the same issue before.