### PR TITLE
Fix TAS Input Window hotkey focus issues

### DIFF
--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -14,6 +14,7 @@
 #include <QSlider>
 #include <QSpinBox>
 #include <QVBoxLayout>
+#include <QEvent>
 
 #include "Common/CommonTypes.h"
 
@@ -82,6 +83,8 @@ TASInputWindow::TASInputWindow(QWidget* parent) : QDialog(parent)
 
   m_settings_box = new QGroupBox(tr("Settings"));
   m_settings_box->setLayout(settings_layout);
+
+  installEventFilter(this);
 }
 
 int TASInputWindow::GetTurboPressFrames() const
@@ -287,12 +290,19 @@ std::optional<ControlState> TASInputWindow::GetSpinBox(TASSpinBox* spin, int zer
   return (spin->GetValue() - zero) / scale;
 }
 
-void TASInputWindow::focusOutEvent(QFocusEvent* event)
+bool TASInputWindow::eventFilter(QObject* object, QEvent* event)
 {
-  Host::GetInstance()->SetTASInputFullFocus(false);
-}
+  if (event->type() == QEvent::WindowActivate)
+  {
+    Host::GetInstance()->SetTASInputFullFocus(true);
+    return true;
+  }
+    
+  else if (event->type() == QEvent::WindowDeactivate)
+  {
+    Host::GetInstance()->SetTASInputFullFocus(false);
+    return true;
+  }
 
-void TASInputWindow::focusInEvent(QFocusEvent* event)
-{
-  Host::GetInstance()->SetTASInputFullFocus(true);
+  return QDialog::eventFilter(object, event);
 }

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.h
@@ -49,9 +49,6 @@ public:
   int GetTurboReleaseFrames() const;
 
 protected:
-  void focusOutEvent(QFocusEvent* event) override;
-  void focusInEvent(QFocusEvent* event) override;
-
   TASCheckBox* CreateButton(const QString& text, std::string_view group_name,
                             std::string_view control_name, InputOverrider* overrider);
   TASStickBox* CreateStickInputs(const QString& text, std::string_view group_name,
@@ -84,4 +81,6 @@ private:
                                          ControlState controller_state);
   std::optional<ControlState> GetSpinBox(TASSpinBox* spin, int zero, ControlState controller_state,
                                          ControlState scale);
+
+  bool eventFilter(QObject* object, QEvent* event);
 };


### PR DESCRIPTION
Previously I had addressed this in https://github.com/TASLabz/dolphin/pull/26, but the window is considered going out-of-focus if you click on one of its child widgets, such as the face buttons. So while opening the TAS Input Window would allow you to use hotkeys at first, clicking a child widget would prevent it from working for the lifetime of the window.

This opts to use an eventFilter instead, looking for the WindowActivate and WindowDeactivate events. Hotkeys now work regardless of how you manipulate or interact with the TAS Input Window.