### PR TITLE
Fix Visual Studio build order

### DIFF
--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -434,6 +434,9 @@
     <ProjectReference Include="$(DolphinRootDir)Languages\Languages.vcxproj">
       <Project>{0e033be3-2e08-428e-9ae9-bc673efa12b5}</Project>
     </ProjectReference>
+    <ProjectReference Include="$(CoreDir)Scripting\Scripting.vcxproj">
+      <Project>{83794107-D372-4804-B463-E2719B50FB6B}</Project>
+    </ProjectReference>
     <!--
       This project uses its own PCH during compile (because RTTI setting differs),
       but we must also link the "main" pch for the dependants (DolphinLib)

--- a/Source/Core/Scripting/Scripting.vcxproj
+++ b/Source/Core/Scripting/Scripting.vcxproj
@@ -17,6 +17,11 @@
     <Import Project="$(VSPropsDir)PCHUse.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="$(ExternalsDir)nativefiledialog-extended\nfd.vcxproj">
+      <Project>{7E931AE3-A819-4D06-AFDA-A39C372EB8CF}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(ExternalsDir)python\$(Platform)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/Source/dolphin-emu.sln
+++ b/Source/dolphin-emu.sln
@@ -87,12 +87,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FatFs", "..\Externals\FatFs
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "spng", "..\Externals\libspng\spng.vcxproj", "{447B7B1E-1D74-4AEF-B2B9-6EB41C5D5313}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Scripting", "Core\Scripting\Scripting.vcxproj", "{83794107-D372-4804-B463-E2719B50FB6B}"
-    ProjectSection(ProjectDependencies) = postProject
-        {7E931AE3-A819-4D06-AFDA-A39C372EB8CF} = {7E931AE3-A819-4D06-AFDA-A39C372EB8CF}
-    EndProjectSection
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "nfd", "..\Externals\nativefiledialog-extended\nfd.vcxproj", "{7E931AE3-A819-4D06-AFDA-A39C372EB8CF}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Scripting", "Core\Scripting\Scripting.vcxproj", "{83794107-D372-4804-B463-E2719B50FB6B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -426,15 +423,15 @@ Global
 		{447B7B1E-1D74-4AEF-B2B9-6EB41C5D5313}.Release|ARM64.Build.0 = Release|ARM64
 		{447B7B1E-1D74-4AEF-B2B9-6EB41C5D5313}.Release|x64.ActiveCfg = Release|x64
 		{447B7B1E-1D74-4AEF-B2B9-6EB41C5D5313}.Release|x64.Build.0 = Release|x64
-		{447B7B1E-1D74-4AEF-B2B9-6EB41C5D5313}.Debug|ARM64.ActiveCfg = Debug|ARM64
-        {83794107-D372-4804-B463-E2719B50FB6B}.Debug|ARM64.ActiveCfg = Debug|ARM64
-        {83794107-D372-4804-B463-E2719B50FB6B}.Debug|ARM64.Build.0 = Debug|ARM64
-        {83794107-D372-4804-B463-E2719B50FB6B}.Debug|x64.ActiveCfg = Debug|x64
-        {83794107-D372-4804-B463-E2719B50FB6B}.Debug|x64.Build.0 = Debug|x64
-        {83794107-D372-4804-B463-E2719B50FB6B}.Release|ARM64.ActiveCfg = Release|ARM64
-        {83794107-D372-4804-B463-E2719B50FB6B}.Release|ARM64.Build.0 = Release|ARM64
-        {83794107-D372-4804-B463-E2719B50FB6B}.Release|x64.ActiveCfg = Release|x64
-        {83794107-D372-4804-B463-E2719B50FB6B}.Release|x64.Build.0 = Release|x64
+		{83794107-D372-4804-B463-E2719B50FB6B}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{83794107-D372-4804-B463-E2719B50FB6B}.Debug|ARM64.Build.0 = Debug|ARM64
+		{83794107-D372-4804-B463-E2719B50FB6B}.Debug|x64.ActiveCfg = Debug|x64
+		{83794107-D372-4804-B463-E2719B50FB6B}.Debug|x64.Build.0 = Debug|x64
+		{83794107-D372-4804-B463-E2719B50FB6B}.Release|ARM64.ActiveCfg = Release|ARM64
+		{83794107-D372-4804-B463-E2719B50FB6B}.Release|ARM64.Build.0 = Release|ARM64
+		{83794107-D372-4804-B463-E2719B50FB6B}.Release|x64.ActiveCfg = Release|x64
+		{83794107-D372-4804-B463-E2719B50FB6B}.Release|x64.Build.0 = Release|x64
+		{7E931AE3-A819-4D06-AFDA-A39C372EB8CF}.Debug|ARM64.ActiveCfg = Debug|ARM64
 		{7E931AE3-A819-4D06-AFDA-A39C372EB8CF}.Debug|ARM64.Build.0 = Debug|ARM64
 		{7E931AE3-A819-4D06-AFDA-A39C372EB8CF}.Debug|x64.ActiveCfg = Debug|x64
 		{7E931AE3-A819-4D06-AFDA-A39C372EB8CF}.Debug|x64.Build.0 = Debug|x64


### PR DESCRIPTION
Previously we had to manually build nfd THEN Scripting THEN Dolphin. I finally figured out how to fix this.

Tested by:
1. Clean Project. Build Dolphin
2. Clean Project. Build Solution

In both scenarios, I now compile successfully.