### PR TITLE
DolphinQt: Allow View->Scripting regardless of debugging UI toggle

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -175,7 +175,6 @@ void MenuBar::OnDebugModeToggled(bool enabled)
   m_show_memory->setVisible(enabled);
   m_show_network->setVisible(enabled);
   m_show_jit->setVisible(enabled);
-  m_show_scripting->setVisible(enabled);
 
   if (enabled)
   {
@@ -385,6 +384,13 @@ void MenuBar::UpdateStateSlotMenu()
 void MenuBar::AddViewMenu()
 {
   QMenu* view_menu = addMenu(tr("&View"));
+
+  QAction* show_scripting = view_menu->addAction(tr("&Scripting"));
+  show_scripting->setCheckable(true);
+  show_scripting->setChecked(Settings::Instance().IsScriptingVisible());
+
+  connect(show_scripting, &QAction::toggled, &Settings::Instance(), &Settings::SetScriptingVisible);
+
   QAction* show_log = view_menu->addAction(tr("Show &Log"));
   show_log->setCheckable(true);
   show_log->setChecked(Settings::Instance().IsLogVisible());
@@ -404,6 +410,8 @@ void MenuBar::AddViewMenu()
 
   connect(show_toolbar, &QAction::toggled, &Settings::Instance(), &Settings::SetToolBarVisible);
 
+  connect(&Settings::Instance(), &Settings::ScriptingVisibilityChanged, show_scripting,
+          &QAction::setChecked);
   connect(&Settings::Instance(), &Settings::LogVisibilityChanged, show_log, &QAction::setChecked);
   connect(&Settings::Instance(), &Settings::LogConfigVisibilityChanged, show_log_config,
           &QAction::setChecked);
@@ -483,12 +491,6 @@ void MenuBar::AddViewMenu()
   m_show_jit->setChecked(Settings::Instance().IsJITVisible());
   connect(m_show_jit, &QAction::toggled, &Settings::Instance(), &Settings::SetJITVisible);
   connect(&Settings::Instance(), &Settings::JITVisibilityChanged, m_show_jit, &QAction::setChecked);
-
-  m_show_scripting = view_menu->addAction(tr("&Scripting"));
-  m_show_scripting->setCheckable(true);
-  m_show_scripting->setChecked(Settings::Instance().IsScriptingVisible());
-  connect(m_show_scripting, &QAction::toggled, &Settings::Instance(), &Settings::SetScriptingVisible);
-  connect(&Settings::Instance(), &Settings::ScriptingVisibilityChanged, m_show_scripting, &QAction::setChecked);
 
   view_menu->addSeparator();
 

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -248,7 +248,6 @@ private:
   QAction* m_show_memory;
   QAction* m_show_network;
   QAction* m_show_jit;
-  QAction* m_show_scripting;
   QMenu* m_cols_menu;
 
   // JIT

--- a/Source/Core/DolphinQt/Scripting/ScriptingWidget.cpp
+++ b/Source/Core/DolphinQt/Scripting/ScriptingWidget.cpp
@@ -65,8 +65,8 @@ ScriptingWidget::ScriptingWidget(QWidget* parent)
   main_widget->setLayout(main_layout);
   this->setWidget(main_widget);
 
-  connect(&Settings::Instance(), &Settings::ScriptingVisibilityChanged,
-          [this](bool visible) { setHidden(!visible); });
+  connect(&Settings::Instance(), &Settings::ScriptingVisibilityChanged, this,
+          &ScriptingWidget::setVisible);
 
   connect(button_add_new, &QPushButton::clicked, this, &ScriptingWidget::AddNewScript);
   connect(button_reload_selected, &QPushButton::clicked, this,
@@ -165,4 +165,9 @@ void ScriptingWidget::ToggleSelectedScripts()
 
   m_scripts_model->dataChanged(index_list.first(), index_list.last(),
                                QList<int>(Qt::CheckStateRole));
+}
+
+void ScriptingWidget::closeEvent(QCloseEvent*)
+{
+  Settings::Instance().SetScriptingVisible(false);
 }

--- a/Source/Core/DolphinQt/Scripting/ScriptingWidget.h
+++ b/Source/Core/DolphinQt/Scripting/ScriptingWidget.h
@@ -21,6 +21,9 @@ public:
   void ToggleSelectedScripts();
   void AddScript(std::string filename, bool enabled = false);
 
+protected:
+  void closeEvent(QCloseEvent*) override;
+
 private:
   bool eventFilter(QObject* object, QEvent* event);
 

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -608,6 +608,7 @@ bool Settings::IsScriptingVisible() const
 void Settings::RefreshWidgetVisibility()
 {
   emit DebugModeToggled(IsDebugModeEnabled());
+  emit ScriptingVisibilityChanged(IsScriptingVisible());
   emit LogVisibilityChanged(IsLogVisible());
   emit LogConfigVisibilityChanged(IsLogConfigVisible());
 }


### PR DESCRIPTION
The user should always be able to (easily) access the Scripting menu, even if debugging UI is not enabled. Scripting is not a debugging-related feature. Previously you had to right click on a currently visible dock object (such as Logs) and use the context menu to navigate to Scripting widgets.

Closing the Scripting widget also would not update the View->Scripting tab (when it was visible with debug enabled at least). So I fixed that as well.

My changes also prevent Dolphin from always opening the Scripting menu on startup. It will now remember whether you last had it enabled/disabled and keep it that until you change it again.