### PR TITLE
DolphinQt: Keep TASInputWindow on top, allow minimize

### DIFF
--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -48,7 +48,8 @@ ControllerEmu::InputOverrideFunction InputOverrider::GetInputOverrideFunction() 
 
 TASInputWindow::TASInputWindow(QWidget* parent) : QDialog(parent)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint | Qt::WindowStaysOnTopHint |
+                 Qt::WindowMinimizeButtonHint);
   setWindowIcon(Resources::GetAppIcon());
 
   QGridLayout* settings_layout = new QGridLayout;


### PR DESCRIPTION
Bringing back the old functionality we're all used to: TAS Input Window staying on-top at all times. However, for those who don't like this feature, I've also enabled the ability the minimize the window. Bringing the window back results in it remaining on-top again.