### PR TITLE
Scripting: Add read_bytes to memory module

### DIFF
--- a/Source/Core/Core/API/Memory.h
+++ b/Source/Core/Core/API/Memory.h
@@ -70,6 +70,11 @@ inline double Read_F64(const Core::CPUThreadGuard& guard, u32 addr)
   return guard.GetSystem().GetMMU().HostRead_F64(guard, addr);
 }
 
+inline char* Read_Bytes(const Core::CPUThreadGuard& guard, u32 addr, u32 size)
+{
+  return guard.GetSystem().GetMMU().HostRead_Bytes(guard, addr, size);
+}
+
 // memory writing: arguments of write functions are swapped (address first) to be consistent with other scripting APIs
 
 inline void InvalidateICache(const Core::CPUThreadGuard &guard, u32 addr, u32 size)
@@ -126,6 +131,11 @@ inline void Write_F32(const Core::CPUThreadGuard& guard, u32 addr, float val)
 inline void Write_F64(const Core::CPUThreadGuard& guard, u32 addr, double val)
 {
   guard.GetSystem().GetMMU().HostWrite_F64(guard, val, addr);
+}
+
+inline void Write_Bytes(const Core::CPUThreadGuard& guard, u32 addr, char* bytes, size_t size)
+{
+  guard.GetSystem().GetMMU().HostWrite_Bytes(guard, addr, bytes, size);
 }
 
 }  // namespace API::Memory

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -139,6 +139,10 @@ public:
   static std::u16string HostGetU16String(const Core::CPUThreadGuard& guard, u32 address,
                                          size_t size = 0);
 
+  template <class T>
+  static size_t ReadAndCopyBytes(const Core::CPUThreadGuard& guard, char* buff, u32 address);
+  static char* HostRead_Bytes(const Core::CPUThreadGuard& guard, u32 address, u32 size);
+
   // Try to read a value from emulated memory at the given address in the given memory space.
   // If the read succeeds, the returned value will be present and the ReadResult contains the read
   // value and information on whether the given address had to be translated or not. Unlike the
@@ -181,6 +185,10 @@ public:
   static void HostWrite_S64(const Core::CPUThreadGuard& guard, u64 var, u32 address);
   static void HostWrite_F32(const Core::CPUThreadGuard& guard, float var, u32 address);
   static void HostWrite_F64(const Core::CPUThreadGuard& guard, double var, u32 address);
+
+  template <class T>
+  static void TWriteBytes(const Core::CPUThreadGuard& guard, char* buff, u32 address);
+  static void HostWrite_Bytes(const Core::CPUThreadGuard& guard, u32 address, char* buff, size_t size);
 
   // Try to a write a value to memory at the given address in the given memory space.
   // If the write succeeds, the returned TryWriteResult contains information on whether the given

--- a/python-stubs/dolphin_memory.pyi
+++ b/python-stubs/dolphin_memory.pyi
@@ -91,6 +91,16 @@ def read_f64(addr: int, /) -> float:
     """
 
 
+def read_bytes(addr: int, size: int, /) -> bytearray:
+    """
+    Reads size bytes and outputs a bytearray of length size.
+    
+    :param addr: memory address to start reading from
+    :param size: number of bytes to read
+    :return: bytearray containing the read bytes
+    """
+
+
 def invalidate_icache(addr: int, size: int, /) -> None:
     """
     Invalidates JIT cached code between the address and address + size, \
@@ -198,4 +208,14 @@ def write_f64(addr: int, value: float, /) -> None:
 
     :param addr: memory address to read from
     :param value: value as floating point number
+    """
+    
+    
+def write_bytes(addr: int, bytes: bytearray, /) -> None:
+    """
+    Writes each byte from the provided bytearray,
+    starting from addr.
+    
+    :param addr: memory address to start writing to
+    :param bytes: bytearray of bytes to write
     """


### PR DESCRIPTION
This adds 2 new functions to the memory module:
- `memory.read_bytes(addr, size)`
- `memory.write_bytes(addr, bytes)` where bytes is a Python `bytearray` object.

I found that it was annoying to read arbitrary number of bytes, such as pulling the Mii data struct byte-by-byte. Instead, this function will allow the user to query Dolphin for a certain number of bytes, and it will return a Python `bytearray`. I went with this as opposed to a `bytes` object, as I think `bytearray` allows for more easy manipulation of the data contained within.

Note that `MMU::ReadFromHardware` contains a translation check to prevent reads from invalid memory. The result is that it will return 0x00 for that byte. **We could debate whether to only return a bytearray with length equal to the number of bytes read successfully, or keep the current behavior that invalid accesses will just return 0x00.**

NOTE: `chase_pointer()` should be updated to support these new functions.

This addresses https://github.com/TASLabz/dolphin/issues/80