### PR TITLE
Scripting: Remove Modules dir from path

### DIFF
--- a/Source/Core/Scripting/Python/PyScriptingBackend.cpp
+++ b/Source/Core/Scripting/Python/PyScriptingBackend.cpp
@@ -35,7 +35,6 @@ static PyThreadState* InitMainPythonInterpreter()
       UTF8ToWString(File::GetExeDirectory()) + L"/python-embed/python38.zip;" +
       UTF8ToWString(File::GetExeDirectory()) + L"/python-embed;" +
       UTF8ToWString(File::GetExeDirectory()) + L";" +
-      UTF8ToWString(File::GetUserPath(D_MODULES_IDX)) + L";" +
       UTF8ToWString(File::GetUserPath(D_SCRIPTS_IDX)) + L";";
 #endif
 


### PR DESCRIPTION
https://github.com/TASLabz/mkw-scripts/pull/29 removes the need to add the Modules directory to the Python PATH. The Scripts directory is all we need.