### PR TITLE
Scripting: Add debug module and toggle play function

### DIFF
--- a/Source/Core/Scripting/CMakeLists.txt
+++ b/Source/Core/Scripting/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(scripting
   Python/PyScriptingBackend.h
   Python/Modules/controllermodule.cpp
   Python/Modules/controllermodule.h
+  Python/Modules/debugmodule.cpp
+  Python/Modules/debugmodule.h
   Python/Modules/doliomodule.cpp
   Python/Modules/doliomodule.h
   Python/Modules/dolphinmodule.cpp

--- a/Source/Core/Scripting/Python/Modules/debugmodule.cpp
+++ b/Source/Core/Scripting/Python/Modules/debugmodule.cpp
@@ -1,0 +1,145 @@
+// Copyright 2023 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "debugmodule.h"
+
+#include <Python.h>
+
+#include "Core/Core.h"
+#include "Core/PowerPC/BreakPoints.h"
+#include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
+#include "Scripting/Python/Utils/as_py_func.h"
+#include "Scripting/Python/Utils/module.h"
+
+namespace PyScripting
+{
+
+struct DebugModuleState
+{
+};
+
+static PyObject* SetBreakpoint(PyObject* self, PyObject* args)
+{
+  auto args_opt = Py::ParseTuple<u32>(args);
+  if (!args_opt.has_value())
+    return nullptr;
+  u32 addr = std::get<0>(args_opt.value());
+
+  Core::System::GetInstance().GetPowerPC().GetBreakPoints().Add(addr, false);
+
+  // TODO: How can we inform the BreakpointWidget to update the list of breakpoints?
+  Py_RETURN_NONE;
+}
+
+static PyObject* RemoveBreakpoint(PyObject* self, PyObject* args)
+{
+  auto args_opt = Py::ParseTuple<u32>(args);
+  if (!args_opt.has_value())
+    return nullptr;
+  u32 addr = std::get<0>(args_opt.value());
+
+  Core::System::GetInstance().GetPowerPC().GetBreakPoints().Remove(addr);
+
+  Py_RETURN_NONE;
+}
+
+// Take in a dictionary, because some of these parameters might not be specified
+static PyObject* SetMemoryBreakpoint(PyObject* self, PyObject* args)
+{
+  PyObject* dict = PyTuple_GetItem(args, 0);
+  if (!PyDict_Check(dict))
+    return nullptr;
+
+  TMemCheck check;
+
+  // Did user specify a single address or do they want to breakpoint a range?
+  PyObject* at_obj = PyDict_GetItemString(dict, "At");
+  PyObject* start_obj = PyDict_GetItemString(dict, "Start");
+  PyObject* end_obj = PyDict_GetItemString(dict, "End");
+  if (at_obj)
+  {
+    u32 addr = PyLong_AsUnsignedLong(at_obj);
+    check.start_address = addr;
+    check.end_address = addr;
+    check.is_ranged = false;
+  }
+  else if (start_obj && end_obj)
+  {
+    check.start_address = PyLong_AsUnsignedLong(start_obj);
+    check.end_address = PyLong_AsUnsignedLong(end_obj);
+    check.is_ranged = true;
+  }
+
+  PyObject* break_read_obj = PyDict_GetItemString(dict, "BreakOnRead");
+  if (break_read_obj)
+    check.is_break_on_read = PyObject_IsTrue(break_read_obj);
+  else
+    check.is_break_on_read = true;
+
+  PyObject* break_write_obj = PyDict_GetItemString(dict, "BreakOnWrite");
+  if (break_write_obj)
+    check.is_break_on_write = PyObject_IsTrue(break_write_obj);
+  else
+    check.is_break_on_write = false;
+
+  PyObject* log_hit_obj = PyDict_GetItemString(dict, "LogOnHit");
+  if (log_hit_obj)
+    check.log_on_hit = PyObject_IsTrue(log_hit_obj);
+  else
+    check.log_on_hit = true;
+
+  PyObject* break_hit_obj = PyDict_GetItemString(dict, "BreakOnHit");
+  if (break_hit_obj)
+    check.break_on_hit = PyObject_IsTrue(break_hit_obj);
+  else
+    check.break_on_hit = true;
+
+  PyObject* expr_obj = PyDict_GetItemString(dict, "Condition");
+  if (expr_obj)
+  {
+    const char* expr = PyUnicode_AsUTF8(expr_obj);
+    check.condition = Expression::TryParse(std::string_view(expr));
+  }
+  else
+    check.condition = std::nullopt;
+
+  Core::System::GetInstance().GetPowerPC().GetMemChecks().Add(std::move(check));
+
+  Py_RETURN_NONE;
+}
+
+static PyObject* RemoveMemoryBreakpoint(PyObject* self, PyObject* args)
+{
+  auto args_opt = Py::ParseTuple<u32>(args);
+  if (!args_opt.has_value())
+    return nullptr;
+  u32 addr = std::get<0>(args_opt.value());
+
+  Core::System::GetInstance().GetPowerPC().GetMemChecks().Remove(addr);
+
+  Py_RETURN_NONE;
+}
+
+static void SetupDebugModule(PyObject* module, DebugModuleState* state)
+{
+}
+
+PyMODINIT_FUNC PyInit_debug()
+{
+  static PyMethodDef methods[] = {
+      {"set_breakpoint", SetBreakpoint, METH_VARARGS, ""},
+      {"remove_breakpoint", RemoveBreakpoint, METH_VARARGS, ""},
+      {"set_memory_breakpoint", SetMemoryBreakpoint, METH_VARARGS, ""},
+      {"remove_memory_breakpoint", RemoveMemoryBreakpoint, METH_VARARGS, ""},
+
+      {nullptr, nullptr, 0, nullptr}  // Sentinel
+  };
+  static PyModuleDef module_def =
+      Py::MakeStatefulModuleDef<DebugModuleState, SetupDebugModule>("debug", methods);
+  PyObject* def_obj = PyModuleDef_Init(&module_def);
+  return def_obj;
+}
+
+}  // namespace PyScripting

--- a/Source/Core/Scripting/Python/Modules/debugmodule.h
+++ b/Source/Core/Scripting/Python/Modules/debugmodule.h
@@ -1,0 +1,14 @@
+// Copyright 2023 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <Python.h>
+
+namespace PyScripting
+{
+
+PyMODINIT_FUNC PyInit_debug();
+
+}

--- a/Source/Core/Scripting/Python/Modules/dolphinmodule.cpp
+++ b/Source/Core/Scripting/Python/Modules/dolphinmodule.cpp
@@ -36,6 +36,7 @@ Invalid:
   from dolphin.event import ...
 """
 
+import dolphin_debug as debug
 import dolphin_event as event
 import dolphin_memory as memory
 import dolphin_gui as gui
@@ -46,7 +47,7 @@ import dolphin_utils as utils
 
 # defining __all__ let's people import everything
 # using a star-import: from dolphin import *
-__all__ = [event, memory, gui, savestate, controller, registers, utils]
+__all__ = [debug, event, memory, gui, savestate, controller, registers, utils]
 )";
   Py::Object result = Py::LoadPyCodeIntoModule(module, pycode);
   if (result.IsNull())

--- a/Source/Core/Scripting/Python/PyScriptingBackend.cpp
+++ b/Source/Core/Scripting/Python/PyScriptingBackend.cpp
@@ -13,6 +13,7 @@
 
 #include "Scripting/Python/coroutine.h"
 #include "Scripting/Python/Modules/controllermodule.h"
+#include "Scripting/Python/Modules/debugmodule.h"
 #include "Scripting/Python/Modules/doliomodule.h"
 #include "Scripting/Python/Modules/dolphinmodule.h"
 #include "Scripting/Python/Modules/eventmodule.h"
@@ -44,6 +45,8 @@ static PyThreadState* InitMainPythonInterpreter()
     ERROR_LOG_FMT(SCRIPTING, "failed to add dolio_stderr to builtins");
   if (PyImport_AppendInittab("dolphin_memory", PyInit_memory) == -1)
     ERROR_LOG_FMT(SCRIPTING, "failed to add dolphin_memory to builtins");
+  if (PyImport_AppendInittab("dolphin_debug", PyInit_debug) == -1)
+    ERROR_LOG_FMT(SCRIPTING, "failed to add dolphin_debug to builtins");
   if (PyImport_AppendInittab("dolphin_event", PyInit_event) == -1)
     ERROR_LOG_FMT(SCRIPTING, "failed to add dolphin_event to builtins");
   if (PyImport_AppendInittab("dolphin_gui", PyInit_gui) == -1)

--- a/Source/Core/Scripting/Scripting.vcxproj
+++ b/Source/Core/Scripting/Scripting.vcxproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <ClCompile Include="Python\coroutine.cpp" />
     <ClCompile Include="Python\Modules\controllermodule.cpp" />
+    <ClCompile Include="Python\Modules\debugmodule.cpp" />
     <ClCompile Include="Python\Modules\doliomodule.cpp" />
     <ClCompile Include="Python\Modules\dolphinmodule.cpp" />
     <ClCompile Include="Python\Modules\eventmodule.cpp" />
@@ -54,6 +55,7 @@
     <ClInclude Include="ScriptList.h" />
     <ClInclude Include="Python\coroutine.h" />
     <ClInclude Include="Python\Modules\controllermodule.h" />
+    <ClInclude Include="Python\Modules\debugmodule.h" />
     <ClInclude Include="Python\Modules\doliomodule.h" />
     <ClInclude Include="Python\Modules\dolphinmodule.h" />
     <ClInclude Include="Python\Modules\eventmodule.h" />

--- a/Source/Core/Scripting/Scripting.vcxproj.filters
+++ b/Source/Core/Scripting/Scripting.vcxproj.filters
@@ -5,6 +5,9 @@
     <ClCompile Include="Python\PyScriptingBackend.cpp">
       <Filter>Python</Filter>
     </ClCompile>
+    <ClCompile Include="Python\Modules\debugmodule.cpp">
+      <Filter>Python\Modules</Filter>
+    </ClCompile>
     <ClCompile Include="Python\Modules\doliomodule.cpp">
       <Filter>Python\Modules</Filter>
     </ClCompile>
@@ -44,6 +47,12 @@
     <ClInclude Include="ScriptingEngine.h" />
     <ClInclude Include="Python\coroutine.h">
       <Filter>Python</Filter>
+    </ClInclude>
+    <ClInclude Include="Python\Modules\controllermodule.h">
+      <Filter>Python\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Python\Modules\debugmodule.h">
+      <Filter>Python\Modules</Filter>
     </ClInclude>
     <ClInclude Include="Python\Modules\doliomodule.h">
       <Filter>Python\Modules</Filter>

--- a/python-stubs/dolphin_debug.pyi
+++ b/python-stubs/dolphin_debug.pyi
@@ -25,7 +25,7 @@ def set_memory_breakpoint(params: dict, /) -> None:
         - "At": u32 - the address to set the memory breakpoint at
         - "Start": u32, "End": u32 - the range of addresses to breakpoint within
         Followed by any of the following optional breakpoints:
-        - "BreakOnRoad": bool - whether the bp should trigger on memory read
+        - "BreakOnRead": bool - whether the bp should trigger on memory read
         - "BreakOnWrite": bool - whether the bp should trigger on memory write
         - "LogOnHit": bool - whether Dolphin should log when the bp is hit
         - "BreakOnHit": bool - whether execution should pause when the bp is hit

--- a/python-stubs/dolphin_debug.pyi
+++ b/python-stubs/dolphin_debug.pyi
@@ -1,0 +1,274 @@
+"""Module for interacting with Dolphin's debugger."""
+
+def set_breakpoint(addr: int, /) -> None:
+    """
+    Sets an instruction breakpoint at addr.
+    
+    :param addr:  address to set the breakpoint at
+    """
+    
+    
+def remove_breakpoint(addr: int, /) -> None:
+    """
+    Removes the breakpoint at addr, if present.
+    
+    :param addr: address of the breakpoint to remove
+    """
+    
+    
+def set_memory_breakpoint(params: dict, /) -> None:
+    """
+    Sets a memory breakpoint with
+    parameters specified by params.
+    
+    :param params: must have one of the following set of keys:
+        - "At": u32 - the address to set the memory breakpoint at
+        - "Start": u32, "End": u32 - the range of addresses to breakpoint within
+        Followed by any of the following optional breakpoints:
+        - "BreakOnRoad": bool - whether the bp should trigger on memory read
+        - "BreakOnWrite": bool - whether the bp should trigger on memory write
+        - "LogOnHit": bool - whether Dolphin should log when the bp is hit
+        - "BreakOnHit": bool - whether execution should pause when the bp is hit
+        - "Condition": str - set a condition for the breakpoint to be hit.
+                             GPRs can be referenced by r0-r31 and FPRs by f0-f31.
+                             You can also use lr, ctr, and pc.
+    
+    """
+
+
+def remove_memory_breakpoint(addr: int, /) -> None:
+    """
+    Remove the memory breakpoint at the specified addr.
+    
+    :param addr: address of the breakpoint to remove
+    """
+
+
+
+
+
+
+
+
+
+
+
+
+def read_u8(addr: int, /) -> int:
+    """
+    Reads 1 byte as an unsigned integer.
+
+    :param addr: memory address to read from
+    :return: value as integer
+    """
+
+
+def read_u16(addr: int, /) -> int:
+    """
+    Reads 2 bytes as an unsigned integer.
+
+    :param addr: memory address to read from
+    :return: value as integer
+    """
+
+
+def read_u32(addr: int, /) -> int:
+    """
+    Reads 4 bytes as an unsigned integer.
+
+    :param addr: memory address to read from
+    :return: value as integer
+    """
+
+
+def read_u64(addr: int, /) -> int:
+    """
+    Reads 8 bytes as an unsigned integer.
+
+    :param addr: memory address to read from
+    :return: value as integer
+    """
+
+
+def read_s8(addr: int, /) -> int:
+    """
+    Reads 1 byte as a signed integer.
+
+    :param addr: memory address to read from
+    :return: value as integer
+    """
+
+
+def read_s16(addr: int, /) -> int:
+    """
+    Reads 2 bytes as a signed integer.
+
+    :param addr: memory address to read from
+    :return: value as integer
+    """
+
+
+def read_s32(addr: int, /) -> int:
+    """
+    Reads 4 bytes as a signed integer.
+
+    :param addr: memory address to read from
+    :return: value as integer
+    """
+
+
+def read_s64(addr: int, /) -> int:
+    """
+    Reads 8 bytes as a signed integer.
+
+    :param addr: memory address to read from
+    :return: value as integer
+    """
+
+
+def read_f32(addr: int, /) -> float:
+    """
+    Reads 4 bytes as a floating point number.
+
+    :param addr: memory address to read from
+    :return: value as floating point number
+    """
+
+
+def read_f64(addr: int, /) -> float:
+    """
+    Reads 8 bytes as a floating point number.
+
+    :param addr: memory address to read from
+    :return: value as floating point number
+    """
+
+
+def read_bytes(addr: int, size: int, /) -> bytearray:
+    """
+    Reads size bytes and outputs a bytearray of length size.
+    
+    :param addr: memory address to start reading from
+    :param size: number of bytes to read
+    :return: bytearray containing the read bytes
+    """
+
+
+def invalidate_icache(addr: int, size: int, /) -> None:
+    """
+    Invalidates JIT cached code between the address and address + size, \
+        forcing the JIT to refetch instructions instead of executing from its cache.
+
+    :param addr: memory address to start invalidation at
+    :param size: size of the cache as integer
+    """
+
+
+def write_u8(addr: int, value: int, /) -> None:
+    """
+    Writes an unsigned integer to 1 byte.
+    Overflowing values are truncated.
+
+    :param addr: memory address to read from
+    :param value: value as integer
+    """
+
+
+def write_u16(addr: int, value: int, /) -> None:
+    """
+    Writes an unsigned integer to 2 bytes.
+    Overflowing values are truncated.
+
+    :param addr: memory address to read from
+    :param value: value as integer
+    """
+
+
+def write_u32(addr: int, value: int, /) -> None:
+    """
+    Writes an unsigned integer to 4 bytes.
+    Overflowing values are truncated.
+
+    :param addr: memory address to read from
+    :param value: value as integer
+    """
+
+
+def write_u64(addr: int, value: int, /) -> None:
+    """
+    Writes an unsigned integer to 8 bytes.
+    Overflowing values are truncated.
+
+    :param addr: memory address to read from
+    :param value: value as integer
+    """
+
+
+def write_s8(addr: int, value: int, /) -> None:
+    """
+    Writes a signed integer to 1 byte.
+    Overflowing values are truncated.
+
+    :param addr: memory address to read from
+    :param value: value as integer
+    """
+
+
+def write_s16(addr: int, value: int, /) -> None:
+    """
+    Writes a signed integer to 2 bytes.
+    Overflowing values are truncated.
+
+    :param addr: memory address to read from
+    :param value: value as integer
+    """
+
+
+def write_s32(addr: int, value: int, /) -> None:
+    """
+    Writes a signed integer to 4 bytes.
+    Overflowing values are truncated.
+
+    :param addr: memory address to read from
+    :param value: value as integer
+    """
+
+
+def write_s64(addr: int, value: int, /) -> None:
+    """
+    Writes a signed integer to 8 bytes.
+    Overflowing values are truncated.
+
+    :param addr: memory address to read from
+    :param value: value as integer
+    """
+
+
+def write_f32(addr: int, value: float, /) -> None:
+    """
+    Writes a floating point number to 4 bytes.
+    Overflowing values are truncated.
+
+    :param addr: memory address to read from
+    :param value: value as floating point number
+    """
+
+
+def write_f64(addr: int, value: float, /) -> None:
+    """
+    Writes a floating point number to 8 bytes.
+    Overflowing values are truncated.
+
+    :param addr: memory address to read from
+    :param value: value as floating point number
+    """
+    
+    
+def write_bytes(addr: int, bytes: bytearray, /) -> None:
+    """
+    Writes each byte from the provided bytearray,
+    starting from addr.
+    
+    :param addr: memory address to start writing to
+    :param bytes: bytearray of bytes to write
+    """

--- a/python-stubs/dolphin_debug.pyi
+++ b/python-stubs/dolphin_debug.pyi
@@ -25,7 +25,7 @@ def set_memory_breakpoint(params: dict, /) -> None:
         - "At": u32 - the address to set the memory breakpoint at
         - "Start": u32, "End": u32 - the range of addresses to breakpoint within
         Followed by any of the following optional breakpoints:
-        - "BreakOnRead": bool - whether the bp should trigger on memory read
+        - "BreakOnRoad": bool - whether the bp should trigger on memory read
         - "BreakOnWrite": bool - whether the bp should trigger on memory write
         - "LogOnHit": bool - whether Dolphin should log when the bp is hit
         - "BreakOnHit": bool - whether execution should pause when the bp is hit
@@ -42,16 +42,6 @@ def remove_memory_breakpoint(addr: int, /) -> None:
     
     :param addr: address of the breakpoint to remove
     """
-
-
-
-
-
-
-
-
-
-
 
 
 def read_u8(addr: int, /) -> int:
@@ -156,8 +146,8 @@ def read_bytes(addr: int, size: int, /) -> bytearray:
 
 def invalidate_icache(addr: int, size: int, /) -> None:
     """
-    Invalidates JIT cached code between the address and address + size, \
-        forcing the JIT to refetch instructions instead of executing from its cache.
+    Invalidates JIT cached code between the address and address + size,
+    forcing the JIT to refetch instructions instead of executing from its cache.
 
     :param addr: memory address to start invalidation at
     :param size: size of the cache as integer

--- a/python-stubs/dolphin_utils.pyi
+++ b/python-stubs/dolphin_utils.pyi
@@ -52,3 +52,7 @@ def is_audiodumping() -> bool:
 
 def save_screenshot(filename: str | None = None) -> None:
     """Saves a screenshot of the running game."""
+
+
+def toggle_play() -> None:
+    """Plays/Pauses the current game."""


### PR DESCRIPTION
I will need further testing, possibly by @vabold to verify the integrity of my implementations here.

Add the ability to set/remove BPs and memory BPs. Memory BPs can be created for a given address, or for a range of address, and can be configured equally as much as via the debugger UI.

Given that hitting BPs pauses the game, I also added a toggle_play function as well to resume after hit. This can be done by responding to the @event.memorybreakpoint or codebreakpoint callbacks.

I didn't know how to define the possible dictionary schema in the stub. Hopefully how I have it is fine.