### PR TITLE
Scripting: Add toolbar button

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -685,6 +685,7 @@ void MainWindow::ConnectToolBar()
   connect(m_tool_bar, &ToolBar::SettingsPressed, this, &MainWindow::ShowSettingsWindow);
   connect(m_tool_bar, &ToolBar::ControllersPressed, this, &MainWindow::ShowControllersWindow);
   connect(m_tool_bar, &ToolBar::GraphicsPressed, this, &MainWindow::ShowGraphicsWindow);
+  connect(m_tool_bar, &ToolBar::ScriptingPressed, this, &MainWindow::ShowScriptingWidget);
 
   connect(m_tool_bar, &ToolBar::StepPressed, m_code_widget, &CodeWidget::Step);
   connect(m_tool_bar, &ToolBar::StepOverPressed, m_code_widget, &CodeWidget::StepOver);
@@ -1242,6 +1243,12 @@ void MainWindow::ShowControllersWindow()
   m_controllers_window->show();
   m_controllers_window->raise();
   m_controllers_window->activateWindow();
+}
+
+void MainWindow::ShowScriptingWidget()
+{
+  Settings& settings = Settings::Instance();
+  settings.SetScriptingVisible(!settings.IsScriptingVisible());
 }
 
 void MainWindow::ShowFreeLookWindow()

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -162,6 +162,7 @@ private:
   void ShowAudioWindow();
   void ShowControllersWindow();
   void ShowGraphicsWindow();
+  void ShowScriptingWidget();
   void ShowFreeLookWindow();
   void ShowAboutDialog();
   void ShowHotkeyDialog();

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -130,13 +130,17 @@ void ToolBar::MakeActions()
   m_graphics_action = addAction(tr("Graphics"), this, &ToolBar::GraphicsPressed);
   m_controllers_action = addAction(tr("Controllers"), this, &ToolBar::ControllersPressed);
 
+  addSeparator();
+
+  m_script_action = addAction(tr("Scripts"), this, &ToolBar::ScriptingPressed);
+
   // Ensure every button has about the same width
   std::vector<QWidget*> items;
   for (const auto& action :
        {m_open_action, m_pause_play_action, m_stop_action, m_stop_action, m_fullscreen_action,
         m_screenshot_action, m_config_action, m_graphics_action, m_controllers_action,
-        m_step_action, m_step_over_action, m_step_out_action, m_skip_action, m_show_pc_action,
-        m_set_pc_action})
+        m_script_action, m_step_action, m_step_over_action, m_step_out_action, m_skip_action,
+        m_show_pc_action, m_set_pc_action})
   {
     items.emplace_back(widgetForAction(action));
   }
@@ -193,4 +197,5 @@ void ToolBar::UpdateIcons()
   m_config_action->setIcon(Resources::GetThemeIcon("config"));
   m_controllers_action->setIcon(Resources::GetThemeIcon("classic"));
   m_graphics_action->setIcon(Resources::GetThemeIcon("graphics"));
+  m_script_action->setIcon(Resources::GetThemeIcon("browse"));
 }

--- a/Source/Core/DolphinQt/ToolBar.h
+++ b/Source/Core/DolphinQt/ToolBar.h
@@ -32,6 +32,7 @@ signals:
   void SettingsPressed();
   void ControllersPressed();
   void GraphicsPressed();
+  void ScriptingPressed();
 
   void StepPressed();
   void StepOverPressed();
@@ -57,6 +58,7 @@ private:
   QAction* m_config_action;
   QAction* m_controllers_action;
   QAction* m_graphics_action;
+  QAction* m_script_action;
 
   QAction* m_step_action;
   QAction* m_step_over_action;


### PR DESCRIPTION
Given that Scripting is the main use of this build, it makes sense to have it quickly accessible via the toolbar. I used a pre-existing icon that I don't believe is used anywhere???
![image](https://github.com/TASLabz/dolphin/assets/16770560/7c309353-2aac-4226-b74f-b1605d316e03)
